### PR TITLE
[+] .net core support (+ unit tests)

### DIFF
--- a/build/ZeroLog.nuspec
+++ b/build/ZeroLog.nuspec
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package >
+<package>
   <metadata>
     <id>ZeroLog</id>
     <authors>Reda Bouallou, Mendel Monteiro-Beckerman, Romain Verdier</authors>
@@ -17,7 +17,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="Release\ZeroLog.dll" target="lib\net45" />
-    <file src="Release\ZeroLog.pdb" target="lib\net45" />
+    <file src="netstandard2.0.\*" target="lib\netstandard2.0" />
   </files>
 </package>

--- a/build/build.cake
+++ b/build/build.cake
@@ -8,6 +8,7 @@
 var target = Argument("target", "Default");
 var paths = new {
     solution = MakeAbsolute(File("./../src/ZeroLog.sln")).FullPath,
+    project  = MakeAbsolute(File("./../src/ZeroLog/ZeroLog.csproj")).FullPath,
     version = MakeAbsolute(File("./../version.yml")).FullPath,
     assemblyInfo = MakeAbsolute(File("./../src/SharedVersionInfo.cs")).FullPath,
     output = new {
@@ -52,7 +53,7 @@ Task("Create-AssemblyInfo").Does(()=>{
     });
 });
 Task("Build-Release").Does(() => Build("Release", paths.output.build));
-Task("Build-Release-Core").Does(() => DotNetCoreBuild(paths.solution, new DotNetCoreBuildSettings { Configuration = "Release" }));
+Task("Build-Release-Core").Does(() => DotNetCoreBuild(paths.project, new DotNetCoreBuildSettings { Framework = "netstandard2.0", Configuration = "Release", OutputDirectory = paths.output.build + "/netstandard2.0"} ));
 Task("Clean-AssemblyInfo").Does(() => System.IO.File.WriteAllText(paths.assemblyInfo, string.Empty));
 Task("Run-Release-Unit-Tests").Does(() => DotNetCoreTest(paths.testProject, new DotNetCoreTestSettings { Configuration = "Release", Framework = "net462" }));
 Task("Run-Release-Unit-Tests-Core").Does(() => DotNetCoreTest(paths.testProject, new DotNetCoreTestSettings { Configuration = "Release", Framework = "netcoreapp2.0" }));

--- a/build/build.cake
+++ b/build/build.cake
@@ -1,5 +1,5 @@
 #l "scripts/utilities.cake"
-#tool nuget:?package=NUnit.Runners.Net4&version=2.6.4
+#tool nuget:?package=NUnit.ConsoleRunner&version=3.7.0
 
 //////////////////////////////////////////////////////////////////////
 // ARGUMENTS
@@ -15,6 +15,7 @@ var paths = new {
         nuget = MakeAbsolute(Directory("./../output/nuget")).FullPath,
     },
     nuspec = MakeAbsolute(File("./ZeroLog.nuspec")).FullPath,
+    testProject = MakeAbsolute(File("./../src/ZeroLog.Tests/ZeroLog.Tests.csproj")).FullPath,
 };
 
 ReadContext(paths.version);
@@ -40,7 +41,7 @@ Task("Clean").Does(() =>
     CleanDirectory(paths.output.build);
     CleanDirectory(paths.output.nuget);
 });
-Task("Restore-NuGet-Packages").Does(() => NuGetRestore(paths.solution));
+Task("Restore-NuGet-Packages").Does(() => DotNetCoreRestore(paths.solution));
 Task("Create-AssemblyInfo").Does(()=>{
     Information("Assembly Version: {0}", VersionContext.AssemblyVersion);
     Information("   NuGet Version: {0}", VersionContext.NugetVersion);
@@ -52,9 +53,13 @@ Task("Create-AssemblyInfo").Does(()=>{
 });
 Task("Build-Debug").Does(() => Build("Debug", paths.output.build));
 Task("Build-Release").Does(() => Build("Release", paths.output.build));
+Task("Build-Debug-Core").Does(() => DotNetCoreBuild(paths.solution, new DotNetCoreBuildSettings { Configuration = "Debug" }));
+Task("Build-Release-Core").Does(() => DotNetCoreBuild(paths.solution, new DotNetCoreBuildSettings { Configuration = "Release" }));
 Task("Clean-AssemblyInfo").Does(() => System.IO.File.WriteAllText(paths.assemblyInfo, string.Empty));
-Task("Run-Debug-Unit-Tests").Does(() => NUnit(paths.output.build + "/Debug/*.Tests.exe", new NUnitSettings { Framework = "net-4.6.1", NoResults = true }));
-Task("Run-Release-Unit-Tests").Does(() => NUnit(paths.output.build + "/Release/*.Tests.exe", new NUnitSettings { Framework = "net-4.6.1", NoResults = true }));
+Task("Run-Debug-Unit-Tests").Does(() => DotNetCoreTest(paths.testProject, new DotNetCoreTestSettings { Configuration = "Debug", Framework = "net462" }));
+Task("Run-Release-Unit-Tests").Does(() => DotNetCoreTest(paths.testProject, new DotNetCoreTestSettings { Configuration = "Release", Framework = "net462" }));
+Task("Run-Debug-Unit-Tests-Core").Does(() => DotNetCoreTest(paths.testProject, new DotNetCoreTestSettings { Configuration = "Debug", Framework = "netcoreapp2.0" }));
+Task("Run-Release-Unit-Tests-Core").Does(() => DotNetCoreTest(paths.testProject, new DotNetCoreTestSettings { Configuration = "Release", Framework = "netcoreapp2.0" }));
 Task("Nuget-Pack").Does(() => 
 {
     NuGetPack(paths.nuspec, new NuGetPackSettings {
@@ -75,12 +80,16 @@ Task("Build")
     .IsDependentOn("Create-AssemblyInfo")
     .IsDependentOn("Build-Debug")
     .IsDependentOn("Build-Release")
+    .IsDependentOn("Build-Debug-Core")
+    .IsDependentOn("Build-Release-Core")
     .IsDependentOn("Clean-AssemblyInfo");
 
 Task("Test")
     .IsDependentOn("Build")
     .IsDependentOn("Run-Debug-Unit-Tests")
-    .IsDependentOn("Run-Release-Unit-Tests");
+    .IsDependentOn("Run-Release-Unit-Tests")
+    .IsDependentOn("Run-Debug-Unit-Tests-Core")
+    .IsDependentOn("Run-Release-Unit-Tests-Core");
 
 Task("Nuget")
     .IsDependentOn("Test")

--- a/build/build.cake
+++ b/build/build.cake
@@ -51,14 +51,10 @@ Task("Create-AssemblyInfo").Does(()=>{
         InformationalVersion = VersionContext.NugetVersion + " Commit: " + VersionContext.Git.Sha
     });
 });
-Task("Build-Debug").Does(() => Build("Debug", paths.output.build));
 Task("Build-Release").Does(() => Build("Release", paths.output.build));
-Task("Build-Debug-Core").Does(() => DotNetCoreBuild(paths.solution, new DotNetCoreBuildSettings { Configuration = "Debug" }));
 Task("Build-Release-Core").Does(() => DotNetCoreBuild(paths.solution, new DotNetCoreBuildSettings { Configuration = "Release" }));
 Task("Clean-AssemblyInfo").Does(() => System.IO.File.WriteAllText(paths.assemblyInfo, string.Empty));
-Task("Run-Debug-Unit-Tests").Does(() => DotNetCoreTest(paths.testProject, new DotNetCoreTestSettings { Configuration = "Debug", Framework = "net462" }));
 Task("Run-Release-Unit-Tests").Does(() => DotNetCoreTest(paths.testProject, new DotNetCoreTestSettings { Configuration = "Release", Framework = "net462" }));
-Task("Run-Debug-Unit-Tests-Core").Does(() => DotNetCoreTest(paths.testProject, new DotNetCoreTestSettings { Configuration = "Debug", Framework = "netcoreapp2.0" }));
 Task("Run-Release-Unit-Tests-Core").Does(() => DotNetCoreTest(paths.testProject, new DotNetCoreTestSettings { Configuration = "Release", Framework = "netcoreapp2.0" }));
 Task("Nuget-Pack").Does(() => 
 {
@@ -78,17 +74,13 @@ Task("Build")
     .IsDependentOn("Clean")
     .IsDependentOn("Restore-NuGet-Packages")
     .IsDependentOn("Create-AssemblyInfo")
-    .IsDependentOn("Build-Debug")
     .IsDependentOn("Build-Release")
-    .IsDependentOn("Build-Debug-Core")
     .IsDependentOn("Build-Release-Core")
     .IsDependentOn("Clean-AssemblyInfo");
 
 Task("Test")
     .IsDependentOn("Build")
-    .IsDependentOn("Run-Debug-Unit-Tests")
     .IsDependentOn("Run-Release-Unit-Tests")
-    .IsDependentOn("Run-Debug-Unit-Tests-Core")
     .IsDependentOn("Run-Release-Unit-Tests-Core");
 
 Task("Nuget")

--- a/src/ZeroLog.Benchmarks/LatencyTests/Log4NetMultiProducer.cs
+++ b/src/ZeroLog.Benchmarks/LatencyTests/Log4NetMultiProducer.cs
@@ -10,10 +10,10 @@ namespace ZeroLog.Benchmarks.LatencyTests
     public class Log4NetMultiProducer
     {
         public SimpleLatencyBenchmarkResult Bench(int warmingMessageCount, int totalMessageCount, int producingThreadCount)
-		{
-			var repository = log4net.LogManager.GetRepository(Assembly.GetExecutingAssembly());
+        {
+            var repository = log4net.LogManager.GetRepository(Assembly.GetExecutingAssembly());
 
-			var layout = new PatternLayout("%-4timestamp [%thread] %-5level %logger %ndc - %message%newline");
+            var layout = new PatternLayout("%-4timestamp [%thread] %-5level %logger %ndc - %message%newline");
             layout.ActivateOptions();
             var appender = new Log4NetTestAppender(false);
             appender.ActivateOptions();

--- a/src/ZeroLog.Benchmarks/LatencyTests/Log4NetMultiProducer.cs
+++ b/src/ZeroLog.Benchmarks/LatencyTests/Log4NetMultiProducer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Reflection;
 using HdrHistogram;
 using log4net.Config;
 using log4net.Layout;
@@ -9,16 +10,16 @@ namespace ZeroLog.Benchmarks.LatencyTests
     public class Log4NetMultiProducer
     {
         public SimpleLatencyBenchmarkResult Bench(int warmingMessageCount, int totalMessageCount, int producingThreadCount)
-        {
-            var layout = new PatternLayout("%-4timestamp [%thread] %-5level %logger %ndc - %message%newline");
+		{
+			var repository = log4net.LogManager.GetRepository(Assembly.GetExecutingAssembly());
+
+			var layout = new PatternLayout("%-4timestamp [%thread] %-5level %logger %ndc - %message%newline");
             layout.ActivateOptions();
             var appender = new Log4NetTestAppender(false);
             appender.ActivateOptions();
-            BasicConfigurator.Configure(appender);
+            BasicConfigurator.Configure(repository, appender);
 
-            var logger = log4net.LogManager.GetLogger(nameof(appender));
-
-
+            var logger = log4net.LogManager.GetLogger(repository.Name, nameof(appender));
             var signal = appender.SetMessageCountTarget(totalMessageCount + warmingMessageCount);
 
             var produce = new Func<HistogramBase>(() =>

--- a/src/ZeroLog.Benchmarks/Program.cs
+++ b/src/ZeroLog.Benchmarks/Program.cs
@@ -17,10 +17,9 @@ namespace ZeroLog.Benchmarks
             config.Add(StatisticColumn.P90);
             config.Add(StatisticColumn.P95);
 
-            var benchs = BenchmarkConverter.TypeToBenchmarks(typeof(ThroughputBenchmarks))
-                                     .ToArray();
+            BenchmarkRunInfo benchs = BenchmarkConverter.TypeToBenchmarks(typeof(ThroughputBenchmarks));
 
-            BenchmarkRunner.Run(benchs, config);
+            BenchmarkRunner.Run(benchs.Benchmarks, config);
         }
 
 

--- a/src/ZeroLog.Benchmarks/ThroughputTests/ThroughputBenchmarks.cs
+++ b/src/ZeroLog.Benchmarks/ThroughputTests/ThroughputBenchmarks.cs
@@ -103,8 +103,8 @@ namespace ZeroLog.Benchmarks.ThroughputTests
             layout.ActivateOptions();
             _log4NetTestAppender.ActivateOptions();
 
-			var repository = log4net.LogManager.GetRepository(Assembly.GetExecutingAssembly());
-			log4net.Config.BasicConfigurator.Configure(repository, _log4NetTestAppender);
+            var repository = log4net.LogManager.GetRepository(Assembly.GetExecutingAssembly());
+            log4net.Config.BasicConfigurator.Configure(repository, _log4NetTestAppender);
 
             _log4NetLogger = log4net.LogManager.GetLogger(repository.Name, nameof(Log4Net));
         }

--- a/src/ZeroLog.Benchmarks/ThroughputTests/ThroughputBenchmarks.cs
+++ b/src/ZeroLog.Benchmarks/ThroughputTests/ThroughputBenchmarks.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Reflection;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Attributes.Jobs;
@@ -102,9 +103,10 @@ namespace ZeroLog.Benchmarks.ThroughputTests
             layout.ActivateOptions();
             _log4NetTestAppender.ActivateOptions();
 
-            log4net.Config.BasicConfigurator.Configure(_log4NetTestAppender);
+			var repository = log4net.LogManager.GetRepository(Assembly.GetExecutingAssembly());
+			log4net.Config.BasicConfigurator.Configure(repository, _log4NetTestAppender);
 
-            _log4NetLogger = log4net.LogManager.GetLogger(nameof(Log4Net));
+            _log4NetLogger = log4net.LogManager.GetLogger(repository.Name, nameof(Log4Net));
         }
 
         private void TearDownLog4Net()

--- a/src/ZeroLog.Benchmarks/ZeroLog.Benchmarks.csproj
+++ b/src/ZeroLog.Benchmarks/ZeroLog.Benchmarks.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;net462</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
@@ -14,7 +14,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
+    <DebugType Condition="'$(TargetFramework)' != 'netcoreapp2.0'">Full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
@@ -22,7 +22,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType Condition="'$(TargetFramework)' != 'netcoreapp2.0'">pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
@@ -33,24 +33,27 @@
     <ProjectReference Include="..\ZeroLog.Tests\ZeroLog.Tests.csproj" />
     <ProjectReference Include="..\ZeroLog\ZeroLog.csproj" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
+    <PackageReference Include="Microsoft.NETCore.Platforms" Version="1.1.0" />
+    <PackageReference Include="NETStandard.Library" Version="1.6.1" />
+    <PackageReference Include="BenchmarkDotNet.Toolchains.Roslyn" Version="0.10.12" />
+  </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.10.8" />
-    <PackageReference Include="BenchmarkDotNet.Core" Version="0.10.8" />
-    <PackageReference Include="BenchmarkDotNet.Toolchains.Roslyn" Version="0.10.8" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.10.12" />
+    <PackageReference Include="BenchmarkDotNet.Core" Version="0.10.12" />
     <PackageReference Include="ConsoleTables" Version="2.1.0" />
     <PackageReference Include="HdrHistogram" Version="2.0.0" />
     <PackageReference Include="log4net" Version="2.0.8" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="1.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="2.3.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.3.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="2.4.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.4.0" />
     <PackageReference Include="Microsoft.DotNet.InternalAbstractions" Version="1.0.0" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="1.1.2" />
-    <PackageReference Include="Microsoft.NETCore.Platforms" Version="1.1.0" />
     <PackageReference Include="Microsoft.Win32.Primitives" Version="4.3.0" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.3.0" />
-    <PackageReference Include="NETStandard.Library" Version="1.6.1" />
-    <PackageReference Include="NLog" Version="4.4.11" />
-    <PackageReference Include="NUnit" Version="2.6.4" />
+    <PackageReference Include="NLog" Version="4.5.0-rc06" />
+    <PackageReference Include="NUnit" Version="3.9.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
     <PackageReference Include="System.AppContext" Version="4.3.0" />
     <PackageReference Include="System.Collections" Version="4.3.0" />
     <PackageReference Include="System.Collections.Concurrent" Version="4.3.0" />
@@ -110,7 +113,6 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.ComponentModel.Composition" />
-    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>

--- a/src/ZeroLog.Tests/ZeroLog.Tests.csproj
+++ b/src/ZeroLog.Tests/ZeroLog.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;net462</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
@@ -11,10 +11,11 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+    <StartupObject>ZeroLog.Tests.Program</StartupObject>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
+    <DebugType Condition="'$(TargetFramework)' != 'netcoreapp2.0'">Full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
@@ -23,7 +24,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType Condition="'$(TargetFramework)' != 'netcoreapp2.0'">pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
@@ -37,15 +38,16 @@
   <ItemGroup>
     <PackageReference Include="Castle.Core" Version="4.1.1" />
     <PackageReference Include="Jil" Version="2.15.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
     <PackageReference Include="Moq" Version="4.7.99" />
     <PackageReference Include="NFluent" Version="2.0.0" />
-    <PackageReference Include="NUnit" Version="2.6.4" />
+    <PackageReference Include="NUnit" Version="3.9.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
     <PackageReference Include="Sigil" Version="4.7.0" />
     <PackageReference Include="StringFormatter" Version="1.0.0.10" />
     <PackageReference Include="System.ValueTuple" Version="4.3.1" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Net.Http" />
   </ItemGroup>

--- a/src/ZeroLog/ZeroLog.csproj
+++ b/src/ZeroLog/ZeroLog.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
@@ -13,7 +13,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
+    <DebugType Condition="'$(TargetFramework)' != 'netstandard2.0'">Full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
@@ -22,7 +22,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType Condition="'$(TargetFramework)' != 'netstandard2.0'">pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
@@ -38,9 +38,7 @@
     <PackageReference Include="System.ValueTuple" Version="4.3.1" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\SharedVersionInfo.cs">


### PR DESCRIPTION
I have added .net standard as a target framework for core ZeroLog assembly and .net core app as a target framework for test assemblies. I have also remove several dependencies which are seems not used currently. Several dependencies were updated. Build script was modified to support build/test running under both .net framework 4.6 and .net core platforms. You may also require to replace NuGetPack with DotNetCorePack but I didn't change it. Could you please publish this version for testing purpose if possible? Thanks