### PR TITLE
[+] 'net452' target framework added

### DIFF
--- a/build/ZeroLog.nuspec
+++ b/build/ZeroLog.nuspec
@@ -17,8 +17,10 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="Release\ZeroLog.dll" target="lib\net462" />
-    <file src="Release\ZeroLog.pdb" target="lib\net462" />
+    <file src="net452\ZeroLog.dll" target="lib\net452" />
+    <file src="net452\ZeroLog.pdb" target="lib\net452" />
+    <file src="net462\ZeroLog.dll" target="lib\net462" />
+    <file src="net462\ZeroLog.pdb" target="lib\net462" />
     <file src="netstandard2.0\ZeroLog.dll" target="lib\netstandard2.0" />
     <file src="netstandard2.0\ZeroLog.pdb" target="lib\netstandard2.0" />
   </files>

--- a/build/build.cake
+++ b/build/build.cake
@@ -52,11 +52,13 @@ Task("Create-AssemblyInfo").Does(()=>{
         InformationalVersion = VersionContext.NugetVersion + " Commit: " + VersionContext.Git.Sha
     });
 });
-Task("Build-Release").Does(() => Build("Release", paths.output.build));
-Task("Build-Release-Core").Does(() => DotNetCoreBuild(paths.project, new DotNetCoreBuildSettings { Framework = "netstandard2.0", Configuration = "Release", OutputDirectory = paths.output.build + "/netstandard2.0"} ));
+Task("Build-Net452").Does(() => DotNetCoreBuild(paths.project, new DotNetCoreBuildSettings { Framework = "net452", Configuration = "Release", OutputDirectory = paths.output.build + "/net452"} ));
+Task("Build-Net462").Does(() => DotNetCoreBuild(paths.project, new DotNetCoreBuildSettings { Framework = "net462", Configuration = "Release", OutputDirectory = paths.output.build + "/net462"} ));
+Task("Build-NetCore").Does(() => DotNetCoreBuild(paths.project, new DotNetCoreBuildSettings { Framework = "netstandard2.0", Configuration = "Release", OutputDirectory = paths.output.build + "/netstandard2.0"} ));
 Task("Clean-AssemblyInfo").Does(() => System.IO.File.WriteAllText(paths.assemblyInfo, string.Empty));
-Task("Run-Release-Unit-Tests").Does(() => DotNetCoreTest(paths.testProject, new DotNetCoreTestSettings { Configuration = "Release", Framework = "net462" }));
-Task("Run-Release-Unit-Tests-Core").Does(() => DotNetCoreTest(paths.testProject, new DotNetCoreTestSettings { Configuration = "Release", Framework = "netcoreapp2.0" }));
+Task("Run-Unit-Tests-Net452").Does(() => DotNetCoreTest(paths.testProject, new DotNetCoreTestSettings { Configuration = "Release", Framework = "net452" }));
+Task("Run-Unit-Tests-Net462").Does(() => DotNetCoreTest(paths.testProject, new DotNetCoreTestSettings { Configuration = "Release", Framework = "net462" }));
+Task("Run-Unit-Tests-NetCore").Does(() => DotNetCoreTest(paths.testProject, new DotNetCoreTestSettings { Configuration = "Release", Framework = "netcoreapp2.0" }));
 Task("Nuget-Pack").Does(() => 
 {
     NuGetPack(paths.nuspec, new NuGetPackSettings {
@@ -75,14 +77,16 @@ Task("Build")
     .IsDependentOn("Clean")
     .IsDependentOn("Restore-NuGet-Packages")
     .IsDependentOn("Create-AssemblyInfo")
-    .IsDependentOn("Build-Release")
-    .IsDependentOn("Build-Release-Core")
+    .IsDependentOn("Build-Net452")
+    .IsDependentOn("Build-Net462")
+    .IsDependentOn("Build-NetCore")
     .IsDependentOn("Clean-AssemblyInfo");
 
 Task("Test")
     .IsDependentOn("Build")
-    .IsDependentOn("Run-Release-Unit-Tests")
-    .IsDependentOn("Run-Release-Unit-Tests-Core");
+    .IsDependentOn("Run-Unit-Tests-Net452")
+    .IsDependentOn("Run-Unit-Tests-Net462")
+    .IsDependentOn("Run-Unit-Tests-NetCore");
 
 Task("Nuget")
     .IsDependentOn("Test")

--- a/src/ZeroLog.Tests/ZeroLog.Tests.csproj
+++ b/src/ZeroLog.Tests/ZeroLog.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net462</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net462;net452</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>

--- a/src/ZeroLog/ZeroLog.csproj
+++ b/src/ZeroLog/ZeroLog.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462;net452</TargetFrameworks>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>


### PR DESCRIPTION
Currently my application targets 'net45' and cannot use ZeroLog due to it targets 'net462'. I tried to add 'net45' target to ZeroLog but it requires to downgrade several dependencies. But it seems adding 'net452' doesn't require any additional work so could you please publish 'net452' version of ZeroLog assembly? I can also move my application to 'net452' without any problem.
P.S. ZeroLog.Benchmarks will stay with 'net462' only