### PR TITLE
Moving to .net 4.5 with StringFormatter 1.0.0.11

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,2 +1,2 @@
-powershell build\build.ps1 -Script build\build.cake -Target Build
+powershell -ExecutionPolicy Bypass build\build.ps1 -Script build\build.cake -Target Build
 pause

--- a/build/ZeroLog.nuspec
+++ b/build/ZeroLog.nuspec
@@ -14,13 +14,12 @@
 	  <dependencies>
       <dependency id="JetBrains.Annotations" version="10.2.1" />
       <dependency id="StringFormatter" version="1.0.0.10" />
+      <dependency id="System.ValueTuple" version="4.3.1" />
     </dependencies>
   </metadata>
   <files>
-    <file src="net452\ZeroLog.dll" target="lib\net452" />
-    <file src="net452\ZeroLog.pdb" target="lib\net452" />
-    <file src="net462\ZeroLog.dll" target="lib\net462" />
-    <file src="net462\ZeroLog.pdb" target="lib\net462" />
+    <file src="net45\ZeroLog.dll" target="lib\net45" />
+    <file src="net45\ZeroLog.pdb" target="lib\net45" />
     <file src="netstandard2.0\ZeroLog.dll" target="lib\netstandard2.0" />
     <file src="netstandard2.0\ZeroLog.pdb" target="lib\netstandard2.0" />
   </files>

--- a/build/build.cake
+++ b/build/build.cake
@@ -52,12 +52,10 @@ Task("Create-AssemblyInfo").Does(()=>{
         InformationalVersion = VersionContext.NugetVersion + " Commit: " + VersionContext.Git.Sha
     });
 });
-Task("Build-Net452").Does(() => DotNetCoreBuild(paths.project, new DotNetCoreBuildSettings { Framework = "net452", Configuration = "Release", OutputDirectory = paths.output.build + "/net452"} ));
-Task("Build-Net462").Does(() => DotNetCoreBuild(paths.project, new DotNetCoreBuildSettings { Framework = "net462", Configuration = "Release", OutputDirectory = paths.output.build + "/net462"} ));
+Task("Build-Net45").Does(() => DotNetCoreBuild(paths.project, new DotNetCoreBuildSettings { Framework = "net45", Configuration = "Release", OutputDirectory = paths.output.build + "/net45"} ));
 Task("Build-NetCore").Does(() => DotNetCoreBuild(paths.project, new DotNetCoreBuildSettings { Framework = "netstandard2.0", Configuration = "Release", OutputDirectory = paths.output.build + "/netstandard2.0"} ));
 Task("Clean-AssemblyInfo").Does(() => System.IO.File.WriteAllText(paths.assemblyInfo, string.Empty));
-Task("Run-Unit-Tests-Net452").Does(() => DotNetCoreTest(paths.testProject, new DotNetCoreTestSettings { Configuration = "Release", Framework = "net452" }));
-Task("Run-Unit-Tests-Net462").Does(() => DotNetCoreTest(paths.testProject, new DotNetCoreTestSettings { Configuration = "Release", Framework = "net462" }));
+Task("Run-Unit-Tests-Net45").Does(() => DotNetCoreTest(paths.testProject, new DotNetCoreTestSettings { Configuration = "Release", Framework = "net45" }));
 Task("Run-Unit-Tests-NetCore").Does(() => DotNetCoreTest(paths.testProject, new DotNetCoreTestSettings { Configuration = "Release", Framework = "netcoreapp2.0" }));
 Task("Nuget-Pack").Does(() => 
 {
@@ -77,15 +75,13 @@ Task("Build")
     .IsDependentOn("Clean")
     .IsDependentOn("Restore-NuGet-Packages")
     .IsDependentOn("Create-AssemblyInfo")
-    .IsDependentOn("Build-Net452")
-    .IsDependentOn("Build-Net462")
+    .IsDependentOn("Build-Net45")
     .IsDependentOn("Build-NetCore")
     .IsDependentOn("Clean-AssemblyInfo");
 
 Task("Test")
     .IsDependentOn("Build")
-    .IsDependentOn("Run-Unit-Tests-Net452")
-    .IsDependentOn("Run-Unit-Tests-Net462")
+    .IsDependentOn("Run-Unit-Tests-Net45")
     .IsDependentOn("Run-Unit-Tests-NetCore");
 
 Task("Nuget")

--- a/create-nuget-package.bat
+++ b/create-nuget-package.bat
@@ -1,2 +1,2 @@
-powershell build\build.ps1 -Script build\build.cake -Target Nuget
+powershell -ExecutionPolicy Bypass build\build.ps1 -Script build\build.cake -Target Nuget
 pause

--- a/execute-tests.bat
+++ b/execute-tests.bat
@@ -1,2 +1,2 @@
-powershell build\build.ps1 -Script build\build.cake -Target Test
+powershell -ExecutionPolicy Bypass build\build.ps1 -Script build\build.cake -Target Test
 pause

--- a/src/ZeroLog.Tests/ZeroLog.Tests.csproj
+++ b/src/ZeroLog.Tests/ZeroLog.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net462;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net45</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
@@ -44,7 +44,7 @@
     <PackageReference Include="NUnit" Version="3.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
     <PackageReference Include="Sigil" Version="4.7.0" />
-    <PackageReference Include="StringFormatter" Version="1.0.0.10" />
+    <PackageReference Include="StringFormatter" Version="1.0.0.11" />
     <PackageReference Include="System.ValueTuple" Version="4.3.1" />
   </ItemGroup>
   <ItemGroup>

--- a/src/ZeroLog/ZeroLog.csproj
+++ b/src/ZeroLog/ZeroLog.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net462;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
@@ -34,7 +34,7 @@
     <PackageReference Include="JetBrains.Annotations" Version="11.0.0" />
     <PackageReference Include="Jil" Version="2.15.2" />
     <PackageReference Include="Sigil" Version="4.7.0" />
-    <PackageReference Include="StringFormatter" Version="1.0.0.10" />
+    <PackageReference Include="StringFormatter" Version="1.0.0.11" />
     <PackageReference Include="System.ValueTuple" Version="4.3.1" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
As it was expected, I suggest to reduce .net framework requirements to 4.5 version. It seems it is possible now