### PR TITLE
Fix running on Linux. Closes #30.

### DIFF
--- a/src/ZeroLog/Utils/HighResolutionDateTime.cs
+++ b/src/ZeroLog/Utils/HighResolutionDateTime.cs
@@ -18,7 +18,7 @@ namespace ZeroLog.Utils
                 if (!_isAvailable)
                     return DateTime.UtcNow;
 
-                GetSystemTimePreciseAsFileTime(out var filetime);
+	            GetSystemTimePreciseAsFileTime(out var filetime);
                 return DateTime.FromFileTimeUtc(filetime);
             }
         }
@@ -28,8 +28,13 @@ namespace ZeroLog.Utils
         {
             try
             {
-                GetSystemTimePreciseAsFileTime(out _);
+	            GetSystemTimePreciseAsFileTime(out _);
                 return true;
+            }
+            catch (DllNotFoundException)
+            {
+	            // Not running Windows 8 or higher.
+	            return false;
             }
             catch (EntryPointNotFoundException)
             {


### PR DESCRIPTION
Not sure how to write tests for this one since it requires a special platform to run on.

I see no point in having `catch (EntryPointNotFoundException)` (the one you had previously) but left it together with `catch (DllNotFoundException)` for safety.