### PR TITLE
Add span overloads to AppendAsciiString

### DIFF
--- a/src/ZeroLog.Tests/LogEventTests.Append.cs
+++ b/src/ZeroLog.Tests/LogEventTests.Append.cs
@@ -74,6 +74,15 @@ namespace ZeroLog.Tests
         }
 
         [Test]
+        public void should_append_char_span()
+        {
+            _logEvent.AppendAsciiString("abc".AsSpan());
+            _logEvent.WriteToStringBuffer(_output);
+
+            Assert.AreEqual("abc", _output.ToString());
+        }
+
+        [Test]
         public void should_ignore_byte_array_with_negative_length()
         {
             var bytes = Encoding.Default.GetBytes("abc");
@@ -102,6 +111,15 @@ namespace ZeroLog.Tests
         }
 
         [Test]
+        public void should_ignore_empty_char_span()
+        {
+            _logEvent.AppendAsciiString(ReadOnlySpan<char>.Empty);
+            _logEvent.WriteToStringBuffer(_output);
+
+            Assert.AreEqual("", _output.ToString());
+        }
+
+        [Test]
         public void should_truncate_byte_array_after_too_many_args()
         {
             _logEvent.Initialize(Level.Info, null, LogEventArgumentExhaustionStrategy.TruncateMessage);
@@ -124,6 +142,19 @@ namespace ZeroLog.Tests
 
             var bytes = Encoding.Default.GetBytes("abc");
             _logEvent.AppendAsciiString(bytes.AsSpan());
+            _logEvent.WriteToStringBuffer(_output);
+
+            Assert.AreEqual(new string('.', _argCapacity) + LogManager.Config.TruncatedMessageSuffix, _output.ToString());
+        }
+
+        [Test]
+        public void should_truncate_char_span_after_too_many_args()
+        {
+            _logEvent.Initialize(Level.Info, null, LogEventArgumentExhaustionStrategy.TruncateMessage);
+            for (var i = 0; i < _argCapacity; ++i)
+                _logEvent.Append(".");
+
+            _logEvent.AppendAsciiString("abc".AsSpan());
             _logEvent.WriteToStringBuffer(_output);
 
             Assert.AreEqual(new string('.', _argCapacity) + LogManager.Config.TruncatedMessageSuffix, _output.ToString());

--- a/src/ZeroLog.Tests/LogEventTests.Append.cs
+++ b/src/ZeroLog.Tests/LogEventTests.Append.cs
@@ -64,6 +64,16 @@ namespace ZeroLog.Tests
         }
 
         [Test]
+        public void should_append_byte_span()
+        {
+            var bytes = Encoding.Default.GetBytes("abc");
+            _logEvent.AppendAsciiString(bytes.AsSpan());
+            _logEvent.WriteToStringBuffer(_output);
+
+            Assert.AreEqual("abc", _output.ToString());
+        }
+
+        [Test]
         public void should_ignore_byte_array_with_negative_length()
         {
             var bytes = Encoding.Default.GetBytes("abc");
@@ -83,6 +93,15 @@ namespace ZeroLog.Tests
         }
 
         [Test]
+        public void should_ignore_empty_byte_span()
+        {
+            _logEvent.AppendAsciiString(ReadOnlySpan<byte>.Empty);
+            _logEvent.WriteToStringBuffer(_output);
+
+            Assert.AreEqual("", _output.ToString());
+        }
+
+        [Test]
         public void should_truncate_byte_array_after_too_many_args()
         {
             _logEvent.Initialize(Level.Info, null, LogEventArgumentExhaustionStrategy.TruncateMessage);
@@ -91,6 +110,20 @@ namespace ZeroLog.Tests
 
             var bytes = Encoding.Default.GetBytes("abc");
             _logEvent.AppendAsciiString(bytes, bytes.Length);
+            _logEvent.WriteToStringBuffer(_output);
+
+            Assert.AreEqual(new string('.', _argCapacity) + LogManager.Config.TruncatedMessageSuffix, _output.ToString());
+        }
+
+        [Test]
+        public void should_truncate_byte_span_after_too_many_args()
+        {
+            _logEvent.Initialize(Level.Info, null, LogEventArgumentExhaustionStrategy.TruncateMessage);
+            for (var i = 0; i < _argCapacity; ++i)
+                _logEvent.Append(".");
+
+            var bytes = Encoding.Default.GetBytes("abc");
+            _logEvent.AppendAsciiString(bytes.AsSpan());
             _logEvent.WriteToStringBuffer(_output);
 
             Assert.AreEqual(new string('.', _argCapacity) + LogManager.Config.TruncatedMessageSuffix, _output.ToString());
@@ -307,7 +340,7 @@ namespace ZeroLog.Tests
             _logEvent.Append(new Guid("129ac124-e588-47e5-9d3d-fa3a4d174e29"));
             _logEvent.Append(new DateTime(2017, 01, 12, 13, 14, 15));
             _logEvent.Append(new TimeSpan(1, 2, 3, 4, 5));
-            _logEvent.AppendUnmanaged(new UnmanagedStruct(){A = 1, B = 2, C = 3});
+            _logEvent.AppendUnmanaged(new UnmanagedStruct() { A = 1, B = 2, C = 3 });
 
             _logEvent.WriteToStringBuffer(_output);
 

--- a/src/ZeroLog/ForwardingLogEvent.cs
+++ b/src/ZeroLog/ForwardingLogEvent.cs
@@ -38,6 +38,7 @@ namespace ZeroLog
         public ILogEvent AppendAsciiString(byte[]? bytes, int length) => this;
         public unsafe ILogEvent AppendAsciiString(byte* bytes, int length) => this;
         public ILogEvent AppendAsciiString(ReadOnlySpan<byte> bytes) => this;
+        public ILogEvent AppendAsciiString(ReadOnlySpan<char> chars) => this;
 
         public ILogEvent AppendEnum<T>(T value)
             where T : struct, Enum

--- a/src/ZeroLog/ForwardingLogEvent.cs
+++ b/src/ZeroLog/ForwardingLogEvent.cs
@@ -37,6 +37,7 @@ namespace ZeroLog
         public ILogEvent Append(string? s) => this;
         public ILogEvent AppendAsciiString(byte[]? bytes, int length) => this;
         public unsafe ILogEvent AppendAsciiString(byte* bytes, int length) => this;
+        public ILogEvent AppendAsciiString(ReadOnlySpan<byte> bytes) => this;
 
         public ILogEvent AppendEnum<T>(T value)
             where T : struct, Enum

--- a/src/ZeroLog/ILogEvent.cs
+++ b/src/ZeroLog/ILogEvent.cs
@@ -10,6 +10,7 @@ namespace ZeroLog
         ILogEvent Append(string? s);
         ILogEvent AppendAsciiString(byte[]? bytes, int length);
         unsafe ILogEvent AppendAsciiString(byte* bytes, int length);
+        ILogEvent AppendAsciiString(ReadOnlySpan<byte> bytes);
 
         ILogEvent AppendEnum<T>(T value)
             where T : struct, Enum;

--- a/src/ZeroLog/ILogEvent.cs
+++ b/src/ZeroLog/ILogEvent.cs
@@ -11,6 +11,7 @@ namespace ZeroLog
         ILogEvent AppendAsciiString(byte[]? bytes, int length);
         unsafe ILogEvent AppendAsciiString(byte* bytes, int length);
         ILogEvent AppendAsciiString(ReadOnlySpan<byte> bytes);
+        ILogEvent AppendAsciiString(ReadOnlySpan<char> chars);
 
         ILogEvent AppendEnum<T>(T value)
             where T : struct, Enum;

--- a/src/ZeroLog/LogEvent.cs
+++ b/src/ZeroLog/LogEvent.cs
@@ -177,6 +177,32 @@ namespace ZeroLog
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ILogEvent AppendAsciiString(ReadOnlySpan<char> chars)
+        {
+            var remainingBytes = (int)(_endOfBuffer - _dataPointer);
+            remainingBytes -= sizeof(ArgumentType) + sizeof(int);
+
+            var length = chars.Length;
+
+            if (length > remainingBytes)
+            {
+                _isTruncated = true;
+                length = remainingBytes;
+            }
+
+            if (length <= 0 || !PrepareAppend(sizeof(ArgumentType) + sizeof(int) + length))
+                return this;
+
+            AppendArgumentType(ArgumentType.AsciiString);
+            AppendInt32(length);
+
+            foreach (var c in chars.Slice(0, length))
+                *_dataPointer++ = (byte)c;
+
+            return this;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ILogEvent AppendEnum<T>(T value)
             where T : struct, Enum
         {

--- a/src/ZeroLog/LogEvent.cs
+++ b/src/ZeroLog/LogEvent.cs
@@ -154,6 +154,29 @@ namespace ZeroLog
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ILogEvent AppendAsciiString(ReadOnlySpan<byte> bytes)
+        {
+            var remainingBytes = (int)(_endOfBuffer - _dataPointer);
+            remainingBytes -= sizeof(ArgumentType) + sizeof(int);
+
+            var length = bytes.Length;
+
+            if (length > remainingBytes)
+            {
+                _isTruncated = true;
+                length = remainingBytes;
+            }
+
+            if (length <= 0 || !PrepareAppend(sizeof(ArgumentType) + sizeof(int) + length))
+                return this;
+
+            AppendArgumentType(ArgumentType.AsciiString);
+            AppendInt32(length);
+            AppendBytes(bytes.Slice(0, length));
+            return this;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ILogEvent AppendEnum<T>(T value)
             where T : struct, Enum
         {
@@ -446,6 +469,13 @@ namespace ZeroLog
         {
             UnsafeTools.CopyBlockUnaligned(_dataPointer, bytes, (uint)length);
             _dataPointer += length;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void AppendBytes(ReadOnlySpan<byte> bytes)
+        {
+            bytes.CopyTo(new Span<byte>(_dataPointer, bytes.Length));
+            _dataPointer += bytes.Length;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/ZeroLog/NoopLogEvent.cs
+++ b/src/ZeroLog/NoopLogEvent.cs
@@ -34,6 +34,7 @@ namespace ZeroLog
         public ILogEvent AppendAsciiString(byte[]? bytes, int length) => this;
         public unsafe ILogEvent AppendAsciiString(byte* bytes, int length) => this;
         public ILogEvent AppendAsciiString(ReadOnlySpan<byte> bytes) => this;
+        public ILogEvent AppendAsciiString(ReadOnlySpan<char> chars) => this;
 
         public ILogEvent AppendEnum<T>(T value)
             where T : struct, Enum

--- a/src/ZeroLog/NoopLogEvent.cs
+++ b/src/ZeroLog/NoopLogEvent.cs
@@ -33,6 +33,7 @@ namespace ZeroLog
         public ILogEvent Append(string? s) => this;
         public ILogEvent AppendAsciiString(byte[]? bytes, int length) => this;
         public unsafe ILogEvent AppendAsciiString(byte* bytes, int length) => this;
+        public ILogEvent AppendAsciiString(ReadOnlySpan<byte> bytes) => this;
 
         public ILogEvent AppendEnum<T>(T value)
             where T : struct, Enum


### PR DESCRIPTION
I'm not sure why we never added `Span` support before, so maybe I'm missing something, but here's a PR which adds two new overloads to `AppendAsciiString`:

 - `ReadOnlySpan<byte>`
 - `ReadOnlySpan<char>`
