### PR TITLE
Replace Jil with Newtonsoft.Json

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -33,7 +33,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" PrivateAssets="all" />
+    <PackageReference Include="JetBrains.Annotations" Version="2020.1.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/ZeroLog.Benchmarks/FodyWeavers.xsd
+++ b/src/ZeroLog.Benchmarks/FodyWeavers.xsd
@@ -35,6 +35,30 @@
                 </xs:restriction>
               </xs:simpleType>
             </xs:attribute>
+            <xs:attribute name="Warnings">
+              <xs:annotation>
+                <xs:documentation>Defines how warnings should be handled. Default value: Warnings</xs:documentation>
+              </xs:annotation>
+              <xs:simpleType>
+                <xs:restriction base="xs:string">
+                  <xs:enumeration value="Warnings">
+                    <xs:annotation>
+                      <xs:documentation>Emit build warnings (this is the default).</xs:documentation>
+                    </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Ignore">
+                    <xs:annotation>
+                      <xs:documentation>Do not emit warnings.</xs:documentation>
+                    </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Errors">
+                    <xs:annotation>
+                      <xs:documentation>Treat warnings as errors.</xs:documentation>
+                    </xs:annotation>
+                  </xs:enumeration>
+                </xs:restriction>
+              </xs:simpleType>
+            </xs:attribute>
           </xs:complexType>
         </xs:element>
       </xs:all>

--- a/src/ZeroLog.Benchmarks/ZeroLog.Benchmarks.csproj
+++ b/src/ZeroLog.Benchmarks/ZeroLog.Benchmarks.csproj
@@ -14,12 +14,11 @@
     <PackageReference Include="BenchmarkDotNet" Version="0.12.0" />
     <PackageReference Include="ConsoleTables" Version="2.3.0" />
     <PackageReference Include="HdrHistogram" Version="2.5.0" />
-    <PackageReference Include="Fody" Version="6.0.5" PrivateAssets="all" />
-    <PackageReference Include="InlineIL.Fody" Version="1.3.4" PrivateAssets="all" />
+    <PackageReference Include="Fody" Version="6.2.0" PrivateAssets="all" />
+    <PackageReference Include="InlineIL.Fody" Version="1.4.2" PrivateAssets="all" />
     <PackageReference Include="log4net" Version="2.0.8" />
     <PackageReference Include="NLog" Version="4.6.8" />
     <PackageReference Include="System.Net.Sockets" Version="4.3.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 
 </Project>

--- a/src/ZeroLog.Tests/Config/ConfiguratorTests.cs
+++ b/src/ZeroLog.Tests/Config/ConfiguratorTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using Newtonsoft.Json;
 using NFluent;
 using NUnit.Framework;
 using ZeroLog.Appenders;
@@ -32,43 +33,7 @@ namespace ZeroLog.Tests.Config
                 Loggers = new[] { new LoggerDefinition { Name = "Abc.Zebus", Level = Level.Debug, AppenderReferences = new[] { "B" } } }
             };
 
-            var configJson = @"
-            {
-              ""LazyRegisterEnums"": false,
-              ""LogEventArgumentCapacity"": 32,
-              ""LogEventBufferSize"": 5,
-              ""LogEventQueueSize"": 7,
-              ""Appenders"": [{
-                ""AppenderJsonConfig"": {
-                  ""PrefixPattern"": ""[%level] @ %time - %logger: ""
-               },
-               ""AppenderTypeName"": ""ConsoleAppender"",
-               ""Name"": ""A""
-              }, {
-                ""AppenderJsonConfig"": {
-                   ""FilePathRoot"": ""totopath ""
-               },
-               ""AppenderTypeName"": ""DateAndSizeRollingFileAppender"",
-               ""Name"": ""B""
-              }],
-              ""Loggers"": [{
-                ""IncludeParentAppenders"": false,
-                ""AppenderReferences"": [""B""],
-                ""Level"": ""Debug"",
-                ""LogEventPoolExhaustionStrategy"": ""DropLogMessageAndNotifyAppenders"",
-                ""LogEventArgumentExhaustionStrategy"": ""TruncateMessage"",
-                ""Name"": ""Abc.Zebus""
-              }],
-              ""RootLogger"": {
-                ""IncludeParentAppenders"": false,
-                ""AppenderReferences"": [""A""],
-                ""Level"": ""Warn"",
-                ""LogEventPoolExhaustionStrategy"": ""DropLogMessage"",
-                ""LogEventArgumentExhaustionStrategy"": ""TruncateMessage"",
-                ""Name"": null
-              },
-              ""NullDisplayString"": null
-            }";
+            var configJson = JsonConvert.SerializeObject(config);
 
             var loadedConfig = JsonConfigurator.DeserializeConfiguration(configJson);
 

--- a/src/ZeroLog/Appenders/AppenderFactory.cs
+++ b/src/ZeroLog/Appenders/AppenderFactory.cs
@@ -40,7 +40,7 @@ namespace ZeroLog.Appenders
                             .FirstOrDefault(x => x != null);
         }
 
-        private static object GetAppenderParameters(AppenderDefinition definition, Type appenderParameterType)
+        internal static object GetAppenderParameters(AppenderDefinition definition, Type appenderParameterType)
         {
             var appenderParameterJson = JSON.SerializeDynamic(definition.AppenderJsonConfig);
             var appenderParameters = (object)JSON.Deserialize(appenderParameterJson, appenderParameterType);

--- a/src/ZeroLog/Appenders/AppenderFactory.cs
+++ b/src/ZeroLog/Appenders/AppenderFactory.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
-using Jil;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using ZeroLog.Config;
 
 namespace ZeroLog.Appenders
@@ -40,11 +41,22 @@ namespace ZeroLog.Appenders
                             .FirstOrDefault(x => x != null);
         }
 
-        internal static object GetAppenderParameters(AppenderDefinition definition, Type appenderParameterType)
+        internal static object? GetAppenderParameters(AppenderDefinition definition, Type appenderParameterType)
         {
-            var appenderParameterJson = JSON.SerializeDynamic(definition.AppenderJsonConfig);
-            var appenderParameters = (object)JSON.Deserialize(appenderParameterJson, appenderParameterType);
-            return appenderParameters;
+            switch (definition.AppenderJsonConfig)
+            {
+                case null:
+                    return null;
+
+                case JObject jObject:
+                    var json = jObject.ToString(Formatting.None);
+                    return JsonConvert.DeserializeObject(json, appenderParameterType);
+
+                case object obj:
+                    return appenderParameterType.IsInstanceOfType(obj)
+                        ? obj
+                        : null;
+            }
         }
 
         private static Type? GetAppenderParameterType(Type? appenderType)

--- a/src/ZeroLog/FodyWeavers.xsd
+++ b/src/ZeroLog/FodyWeavers.xsd
@@ -35,6 +35,30 @@
                 </xs:restriction>
               </xs:simpleType>
             </xs:attribute>
+            <xs:attribute name="Warnings">
+              <xs:annotation>
+                <xs:documentation>Defines how warnings should be handled. Default value: Warnings</xs:documentation>
+              </xs:annotation>
+              <xs:simpleType>
+                <xs:restriction base="xs:string">
+                  <xs:enumeration value="Warnings">
+                    <xs:annotation>
+                      <xs:documentation>Emit build warnings (this is the default).</xs:documentation>
+                    </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Ignore">
+                    <xs:annotation>
+                      <xs:documentation>Do not emit warnings.</xs:documentation>
+                    </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Errors">
+                    <xs:annotation>
+                      <xs:documentation>Treat warnings as errors.</xs:documentation>
+                    </xs:annotation>
+                  </xs:enumeration>
+                </xs:restriction>
+              </xs:simpleType>
+            </xs:attribute>
           </xs:complexType>
         </xs:element>
       </xs:all>

--- a/src/ZeroLog/Utils/JsonExtensions.cs
+++ b/src/ZeroLog/Utils/JsonExtensions.cs
@@ -1,10 +1,10 @@
-using Jil;
+using Newtonsoft.Json;
 
 namespace ZeroLog.Utils
 {
     public static class JsonExtensions
     {
         public static T DeserializeOrDefault<T>(string? json, T @default)
-            => string.IsNullOrEmpty(json) ? @default : JSON.Deserialize<T>(json);
+            => string.IsNullOrEmpty(json) ? @default : JsonConvert.DeserializeObject<T>(json!);
     }
 }

--- a/src/ZeroLog/ZeroLog.csproj
+++ b/src/ZeroLog/ZeroLog.csproj
@@ -10,12 +10,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Fody" Version="6.0.5" PrivateAssets="all" />
-    <PackageReference Include="InlineIL.Fody" Version="1.3.4" PrivateAssets="all" />
+    <PackageReference Include="Fody" Version="6.2.0" PrivateAssets="all" />
+    <PackageReference Include="InlineIL.Fody" Version="1.4.2" PrivateAssets="all" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="StringFormatter" Version="1.0.0.13" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">

--- a/src/ZeroLog/ZeroLog.csproj
+++ b/src/ZeroLog/ZeroLog.csproj
@@ -12,8 +12,9 @@
   <ItemGroup>
     <PackageReference Include="Fody" Version="6.0.5" PrivateAssets="all" />
     <PackageReference Include="InlineIL.Fody" Version="1.3.4" PrivateAssets="all" />
-    <PackageReference Include="Jil" Version="2.15.4" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="StringFormatter" Version="1.0.0.13" />
+    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Fixes #38

I also noticed the unit tests did not use the same JSON syntax as what is shown in the readme, and the assertion checks were not working.

Hopefully the new code behaves in the same way as the old one.
