### PR TITLE
Update configuration after initialization

### DIFF
--- a/src/ZeroLog.Impl.Full/Configuration/AppenderConfiguration.cs
+++ b/src/ZeroLog.Impl.Full/Configuration/AppenderConfiguration.cs
@@ -34,4 +34,7 @@ public sealed class AppenderConfiguration
     /// <param name="appender">The appender to configure.</param>
     public static implicit operator AppenderConfiguration(Appender appender)
         => new(appender);
+
+    internal AppenderConfiguration Clone()
+        => (AppenderConfiguration)MemberwiseClone();
 }

--- a/src/ZeroLog.Impl.Full/Configuration/AppenderConfiguration.cs
+++ b/src/ZeroLog.Impl.Full/Configuration/AppenderConfiguration.cs
@@ -16,7 +16,7 @@ public sealed class AppenderConfiguration
     /// The minimum log level of messages this appender should handle.
     /// This can be higher than the level defined on the appender.
     /// </summary>
-    public LogLevel Level { get; init; }
+    public LogLevel Level { get; set; }
 
     /// <summary>
     /// Creates a configuration for an appender.

--- a/src/ZeroLog.Impl.Full/Configuration/LoggerConfiguration.cs
+++ b/src/ZeroLog.Impl.Full/Configuration/LoggerConfiguration.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
+using System.Linq;
 using ZeroLog.Appenders;
 
 namespace ZeroLog.Configuration;
@@ -68,7 +68,7 @@ public sealed class LoggerConfiguration : ILoggerConfiguration
     {
     }
 
-    internal void ValidateAndFreeze()
+    internal void Validate()
     {
         var appenderRefs = new HashSet<Appender>(ReferenceEqualityComparer.Instance);
 
@@ -77,8 +77,13 @@ public sealed class LoggerConfiguration : ILoggerConfiguration
             if (!appenderRefs.Add(appenderRef.Appender))
                 throw new InvalidOperationException($"Multiple appender configurations for the same appender instance (of type {appenderRef.Appender.GetType()}) defined in the following logger configuration: {Name}");
         }
+    }
 
-        Appenders = ImmutableList.CreateRange(Appenders);
+    internal LoggerConfiguration Clone()
+    {
+        var clone = (LoggerConfiguration)MemberwiseClone();
+        clone.Appenders = Appenders.Select(i => i.Clone()).ToList();
+        return clone;
     }
 }
 
@@ -110,7 +115,7 @@ public sealed class RootLoggerConfiguration : ILoggerConfiguration
     LogMessagePoolExhaustionStrategy? ILoggerConfiguration.LogMessagePoolExhaustionStrategy => LogMessagePoolExhaustionStrategy;
     bool ILoggerConfiguration.IncludeParentAppenders => false;
 
-    internal void ValidateAndFreeze()
+    internal void Validate()
     {
         var appenderRefs = new HashSet<Appender>(ReferenceEqualityComparer.Instance);
 
@@ -119,8 +124,13 @@ public sealed class RootLoggerConfiguration : ILoggerConfiguration
             if (!appenderRefs.Add(appenderRef.Appender))
                 throw new InvalidOperationException($"Multiple appender configurations for the same appender instance (of type {appenderRef.Appender.GetType()}) defined in the root logger configuration.");
         }
+    }
 
-        Appenders = ImmutableList.CreateRange(Appenders);
+    internal RootLoggerConfiguration Clone()
+    {
+        var clone = (RootLoggerConfiguration)MemberwiseClone();
+        clone.Appenders = Appenders.Select(i => i.Clone()).ToList();
+        return clone;
     }
 }
 

--- a/src/ZeroLog.Impl.Full/Configuration/LoggerConfiguration.cs
+++ b/src/ZeroLog.Impl.Full/Configuration/LoggerConfiguration.cs
@@ -23,7 +23,7 @@ public sealed class LoggerConfiguration : ILoggerConfiguration
     /// <remarks>
     /// The level of the parent logger is inherited by default.
     /// </remarks>
-    public LogLevel? Level { get; init; }
+    public LogLevel? Level { get; set; }
 
     /// <summary>
     /// The strategy to apply on log message pool exhaustion.
@@ -31,7 +31,7 @@ public sealed class LoggerConfiguration : ILoggerConfiguration
     /// <remarks>
     /// The strategy of the parent logger is inherited by default.
     /// </remarks>
-    public LogMessagePoolExhaustionStrategy? LogMessagePoolExhaustionStrategy { get; init; }
+    public LogMessagePoolExhaustionStrategy? LogMessagePoolExhaustionStrategy { get; set; }
 
     /// <summary>
     /// Indicate whether appenders defined on parent levels should be included.
@@ -39,7 +39,7 @@ public sealed class LoggerConfiguration : ILoggerConfiguration
     /// <remarks>
     /// True by default.
     /// </remarks>
-    public bool IncludeParentAppenders { get; init; } = true;
+    public bool IncludeParentAppenders { get; set; } = true;
 
     /// <summary>
     /// The appenders to use for this level.

--- a/src/ZeroLog.Impl.Full/Configuration/ZeroLogConfiguration.cs
+++ b/src/ZeroLog.Impl.Full/Configuration/ZeroLogConfiguration.cs
@@ -116,9 +116,9 @@ public sealed class ZeroLogConfiguration
     internal ResolvedLoggerConfiguration ResolveLoggerConfiguration(string loggerName)
         => ResolvedLoggerConfiguration.Resolve(loggerName, this);
 
-    internal IEnumerable<Appender> GetAllAppenders()
+    internal HashSet<Appender> GetAllAppenders()
         => RootLogger.Appenders
                      .Concat(Loggers.SelectMany(i => i.Appenders))
                      .Select(i => i.Appender)
-                     .DistinctBy(i => i, ReferenceEqualityComparer.Instance);
+                     .ToHashSet<Appender>(ReferenceEqualityComparer.Instance);
 }

--- a/src/ZeroLog.Impl.Full/Configuration/ZeroLogConfiguration.cs
+++ b/src/ZeroLog.Impl.Full/Configuration/ZeroLogConfiguration.cs
@@ -12,6 +12,8 @@ public sealed class ZeroLogConfiguration
 {
     internal static ZeroLogConfiguration Default { get; } = new();
 
+    internal event Action? ApplyChangesRequested;
+
     /// <summary>
     /// Count of pooled log messages. A log message is acquired from the pool on demand, and released by the logging thread.
     /// </summary>
@@ -86,6 +88,16 @@ public sealed class ZeroLogConfiguration
     /// If <c>Foo.Bar</c> is configured, but <c>Foo.Bar.Baz</c> is not, it will use the configuration for <c>Foo.Bar</c>.
     /// </remarks>
     public ICollection<LoggerConfiguration> Loggers { get; private set; } = new List<LoggerConfiguration>();
+
+    /// <summary>
+    /// Applies the changes made to this object since the call to <see cref="LogManager.Initialize"/>
+    /// or the last call to <see cref="ApplyChanges"/>.
+    /// </summary>
+    /// <remarks>
+    /// This method allocates.
+    /// </remarks>
+    public void ApplyChanges()
+        => ApplyChangesRequested?.Invoke();
 
     internal void Validate()
     {

--- a/src/ZeroLog.Impl.Full/Configuration/ZeroLogConfiguration.cs
+++ b/src/ZeroLog.Impl.Full/Configuration/ZeroLogConfiguration.cs
@@ -44,7 +44,7 @@ public sealed class ZeroLogConfiguration
     /// <remarks>
     /// Default: false
     /// </remarks>
-    public bool AutoRegisterEnums { get; init; } = false;
+    public bool AutoRegisterEnums { get; set; } = false;
 
     /// <summary>
     /// The string which should be logged instead of a <c>null</c> value.
@@ -52,7 +52,7 @@ public sealed class ZeroLogConfiguration
     /// <remarks>
     /// Default: "null"
     /// </remarks>
-    public string NullDisplayString { get; init; } = "null";
+    public string NullDisplayString { get; set; } = "null";
 
     /// <summary>
     /// The string which is appended to a message when it is truncated.
@@ -60,7 +60,7 @@ public sealed class ZeroLogConfiguration
     /// <remarks>
     /// Default: " [TRUNCATED]"
     /// </remarks>
-    public string TruncatedMessageSuffix { get; init; } = " [TRUNCATED]";
+    public string TruncatedMessageSuffix { get; set; } = " [TRUNCATED]";
 
     /// <summary>
     /// The time an appender will be put into quarantine (not used to log messages) after it throws an exception.
@@ -68,7 +68,7 @@ public sealed class ZeroLogConfiguration
     /// <remarks>
     /// Default: 15 seconds
     /// </remarks>
-    public TimeSpan AppenderQuarantineDelay { get; init; } = TimeSpan.FromSeconds(15);
+    public TimeSpan AppenderQuarantineDelay { get; set; } = TimeSpan.FromSeconds(15);
 
     /// <summary>
     /// The configuration of the root logger.

--- a/src/ZeroLog.Impl.Full/Formatting/LoggedMessage.cs
+++ b/src/ZeroLog.Impl.Full/Formatting/LoggedMessage.cs
@@ -10,9 +10,9 @@ namespace ZeroLog.Formatting;
 /// </summary>
 public sealed class LoggedMessage
 {
-    private readonly ZeroLogConfiguration _config;
     private readonly char[] _messageBuffer;
     private int _messageLength;
+    private ZeroLogConfiguration _config;
 
     private LogMessage _message = LogMessage.Empty;
 
@@ -64,6 +64,11 @@ public sealed class LoggedMessage
         {
             HandleFormattingError(ex);
         }
+    }
+
+    internal void UpdateConfiguration(ZeroLogConfiguration config)
+    {
+        _config = config;
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/ZeroLog.Impl.Full/LogManager.AppenderThread.cs
+++ b/src/ZeroLog.Impl.Full/LogManager.AppenderThread.cs
@@ -106,6 +106,7 @@ partial class LogManager
                 }
             }
 
+            ApplyConfigurationUpdate(); // Make sure any new appenders are taken into account before disposal
             FlushAppenders();
         }
 
@@ -160,6 +161,12 @@ partial class LogManager
             }
 
             _loggedMessage.UpdateConfiguration(newConfig);
+        }
+
+        public void WaitUntilNewConfigurationIsApplied()
+        {
+            while (Volatile.Read(ref _nextConfig) != null)
+                Thread.Yield();
         }
     }
 }

--- a/src/ZeroLog.Impl.Full/LogManager.AppenderThread.cs
+++ b/src/ZeroLog.Impl.Full/LogManager.AppenderThread.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using ZeroLog.Appenders;
 using ZeroLog.Configuration;
@@ -13,10 +14,13 @@ partial class LogManager
     private class AppenderThread
     {
         private readonly LogManager _logManager;
-        private readonly ZeroLogConfiguration _config;
         private readonly ConcurrentQueue<LogMessage> _queue;
-        private readonly Appender[] _appenders;
         private readonly Thread _thread;
+        private readonly LoggedMessage _loggedMessage;
+
+        private ZeroLogConfiguration _config;
+        private ZeroLogConfiguration? _nextConfig;
+        private Appender[] _appenders;
 
         public AppenderThread(LogManager logManager)
         {
@@ -25,6 +29,7 @@ partial class LogManager
             _queue = logManager._queue;
 
             _appenders = _config.GetAllAppenders().ToArray();
+            _loggedMessage = new LoggedMessage(OutputBufferSize, _config);
 
             _thread = new Thread(WriteThread)
             {
@@ -41,6 +46,13 @@ partial class LogManager
         {
             foreach (var appender in _appenders)
                 appender.Dispose();
+
+            _appenders = Array.Empty<Appender>();
+        }
+
+        public void UpdateConfiguration(ZeroLogConfiguration config)
+        {
+            Volatile.Write(ref _nextConfig, config);
         }
 
         private void WriteThread()
@@ -68,12 +80,11 @@ partial class LogManager
         private void WriteToAppenders()
         {
             var spinWait = new SpinWait();
-            var loggedMessage = new LoggedMessage(OutputBufferSize, _config);
             var flush = false;
 
             while (_logManager._isRunning || !_queue.IsEmpty)
             {
-                if (TryToProcessQueue(loggedMessage))
+                if (TryToProcessQueue())
                 {
                     spinWait.Reset();
                     flush = true;
@@ -85,6 +96,10 @@ partial class LogManager
                     FlushAppenders();
                     flush = false;
                 }
+                else if (_nextConfig is not null)
+                {
+                    ApplyConfigurationUpdate();
+                }
                 else
                 {
                     spinWait.SpinOnce();
@@ -94,7 +109,7 @@ partial class LogManager
             FlushAppenders();
         }
 
-        private bool TryToProcessQueue(LoggedMessage loggedMessage)
+        private bool TryToProcessQueue()
         {
             if (!_queue.TryDequeue(out var logMessage))
                 return false;
@@ -105,10 +120,10 @@ partial class LogManager
                 if (appenders.Length == 0)
                     return true;
 
-                loggedMessage.SetMessage(logMessage);
+                _loggedMessage.SetMessage(logMessage);
 
                 foreach (var appender in appenders)
-                    appender.InternalWriteMessage(loggedMessage, _config);
+                    appender.InternalWriteMessage(_loggedMessage, _config);
             }
             finally
             {
@@ -122,6 +137,29 @@ partial class LogManager
         {
             foreach (var appender in _appenders)
                 appender.InternalFlush();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void ApplyConfigurationUpdate()
+        {
+            var newConfig = Interlocked.Exchange(ref _nextConfig, null);
+            if (newConfig is null)
+                return;
+
+            _config = newConfig;
+
+            // We could dispose the appenders that are no longer present in the new configuration right now,
+            // but the user may want to add them back later, so their state needs to remain valid.
+
+            var appenders = newConfig.GetAllAppenders();
+
+            if (!appenders.SetEquals(_appenders))
+            {
+                appenders.UnionWith(_appenders);
+                _appenders = appenders.ToArray();
+            }
+
+            _loggedMessage.UpdateConfiguration(newConfig);
         }
     }
 }

--- a/src/ZeroLog.Impl.Full/LogManager.Impl.cs
+++ b/src/ZeroLog.Impl.Full/LogManager.Impl.cs
@@ -79,6 +79,8 @@ partial class LogManager : ILogMessageProvider, IDisposable
     /// </remarks>
     public static IDisposable Initialize(ZeroLogConfiguration configuration)
     {
+        ArgumentNullException.ThrowIfNull(configuration);
+
         configuration.Validate();
 
         if (_staticLogManager is not null)
@@ -201,6 +203,9 @@ partial class LogManager : ILogMessageProvider, IDisposable
         foreach (var log in _loggers.Values)
             log.UpdateConfiguration(null, null);
     }
+
+    internal void WaitUntilNewConfigurationIsApplied()
+        => _appenderThread.WaitUntilNewConfigurationIsApplied();
 
     LogMessage? ILogMessageProvider.TryAcquireLogMessage()
     {

--- a/src/ZeroLog.Impl.Full/LogManager.Impl.cs
+++ b/src/ZeroLog.Impl.Full/LogManager.Impl.cs
@@ -40,6 +40,8 @@ partial class LogManager : ILogMessageProvider, IDisposable
 
         // Instantiate this last
         _appenderThread = new AppenderThread(this);
+
+        _originalConfig.ApplyChangesRequested += ApplyConfigurationChanges;
     }
 
     /// <summary>
@@ -53,6 +55,7 @@ partial class LogManager : ILogMessageProvider, IDisposable
         _isRunning = false;
         Interlocked.CompareExchange(ref _staticLogManager, null, this);
 
+        _originalConfig.ApplyChangesRequested -= ApplyConfigurationChanges;
         ResetAllLogConfigurations();
 
         _pool.Clear();
@@ -72,7 +75,7 @@ partial class LogManager : ILogMessageProvider, IDisposable
     /// <returns>A disposable which shuts down ZeroLog upon disposal.</returns>
     /// <exception cref="InvalidOperationException">ZeroLog is already initialized.</exception>
     /// <remarks>
-    /// Any changes to the <paramref name="configuration"/> object will only be taken into account after calling <see cref="UpdateConfiguration"/>.
+    /// Any changes to the <paramref name="configuration"/> object will only be taken into account after calling <see cref="ZeroLogConfiguration.ApplyChanges"/>.
     /// </remarks>
     public static IDisposable Initialize(ZeroLogConfiguration configuration)
     {
@@ -84,15 +87,6 @@ partial class LogManager : ILogMessageProvider, IDisposable
         _staticLogManager = new LogManager(configuration);
         return _staticLogManager;
     }
-
-    /// <summary>
-    /// Applies changes made to the configuration object which was passed to <see cref="Initialize"/>.
-    /// </summary>
-    /// <remarks>
-    /// This method allocates.
-    /// </remarks>
-    public static void UpdateConfiguration()
-        => _staticLogManager?.ApplyConfigurationChanges();
 
     /// <summary>
     /// Shuts down ZeroLog.

--- a/src/ZeroLog.Impl.Full/LogManager.Impl.cs
+++ b/src/ZeroLog.Impl.Full/LogManager.Impl.cs
@@ -24,7 +24,7 @@ partial class LogManager : ILogMessageProvider, IDisposable
 
     private LogManager(ZeroLogConfiguration config)
     {
-        _config = config;
+        _config = config.Clone();
 
         _queue = new ConcurrentQueue<LogMessage>(new ConcurrentQueueCapacityInitializer(config.LogMessagePoolSize));
 
@@ -70,7 +70,7 @@ partial class LogManager : ILogMessageProvider, IDisposable
     /// <exception cref="InvalidOperationException">ZeroLog is already initialized.</exception>
     public static IDisposable Initialize(ZeroLogConfiguration configuration)
     {
-        configuration.ValidateAndFreeze();
+        configuration.Validate();
 
         if (_staticLogManager is not null)
             throw new InvalidOperationException("LogManager is already initialized.");

--- a/src/ZeroLog.Tests/LogManagerTests.Config.cs
+++ b/src/ZeroLog.Tests/LogManagerTests.Config.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Linq;
+using NUnit.Framework;
+using ZeroLog.Configuration;
+using ZeroLog.Tests.Support;
+
+namespace ZeroLog.Tests;
+
+public partial class LogManagerTests
+{
+    [Test]
+    public void should_apply_appender_changes()
+    {
+        var fooLog = LogManager.GetLogger("Foo");
+        var barLog = LogManager.GetLogger("Bar");
+
+        var barAppender = new TestAppender(true);
+
+        _config.Loggers.Add(new LoggerConfiguration(fooLog.Name) { IncludeParentAppenders = false });
+        _config.Loggers.Add(new LoggerConfiguration(barLog.Name) { Appenders = { barAppender } });
+
+        ApplyConfigChanges();
+
+        var rootSignal = _testAppender.SetMessageCountTarget(1);
+        var barSignal = barAppender.SetMessageCountTarget(1);
+
+        fooLog.Info("Foo");
+        barLog.Info("Bar");
+
+        rootSignal.Wait(TimeSpan.FromSeconds(1));
+        barSignal.Wait(TimeSpan.FromSeconds(1));
+
+        _testAppender.LoggedMessages.ShouldHaveSingleItem().ShouldEqual("Bar");
+        barAppender.LoggedMessages.ShouldHaveSingleItem().ShouldEqual("Bar");
+    }
+
+    [Test]
+    public void should_apply_log_level_changes()
+    {
+        var fooLog = LogManager.GetLogger("Foo");
+        var barLog = LogManager.GetLogger("Bar");
+
+        _config.Loggers.Add(new LoggerConfiguration(fooLog.Name) { Level = LogLevel.Warn });
+        ApplyConfigChanges();
+
+        fooLog.IsInfoEnabled.ShouldBeFalse();
+        fooLog.IsWarnEnabled.ShouldBeTrue();
+
+        barLog.IsInfoEnabled.ShouldBeTrue();
+        barLog.IsWarnEnabled.ShouldBeTrue();
+    }
+
+    [Test]
+    public void should_not_apply_changes_until_requested()
+    {
+        var log = LogManager.GetLogger<LogManagerTests>();
+
+        _config.Loggers.Add(new LoggerConfiguration(log.Name) { Level = LogLevel.Warn });
+
+        log.IsInfoEnabled.ShouldBeTrue();
+
+        ApplyConfigChanges();
+
+        log.IsInfoEnabled.ShouldBeFalse();
+    }
+
+    [Test]
+    public void should_dispose_active_appenders_on_shutdown()
+    {
+        var loggerAppender = new TestAppender(false);
+
+        _config.Loggers.Add(new LoggerConfiguration("Foo") { Appenders = { loggerAppender } });
+        ApplyConfigChanges();
+
+        LogManager.Shutdown();
+
+        _testAppender.IsDisposed.ShouldBeTrue();
+        loggerAppender.IsDisposed.ShouldBeTrue();
+    }
+
+    [Test]
+    public void should_dispose_removed_appenders_on_shutdown()
+    {
+        var loggerAppender = new TestAppender(false);
+
+        _config.Loggers.Add(new LoggerConfiguration("Foo") { Appenders = { loggerAppender } });
+        ApplyConfigChanges();
+
+        loggerAppender.IsDisposed.ShouldBeFalse();
+
+        _config.Loggers.Single().Appenders.Clear();
+        ApplyConfigChanges();
+
+        loggerAppender.IsDisposed.ShouldBeFalse();
+
+        _config.Loggers.Clear();
+        ApplyConfigChanges();
+
+        loggerAppender.IsDisposed.ShouldBeFalse();
+
+        LogManager.Shutdown();
+
+        loggerAppender.IsDisposed.ShouldBeTrue();
+    }
+
+    private void ApplyConfigChanges()
+    {
+        _config.ApplyChanges();
+        _logManager.WaitUntilNewConfigurationIsApplied();
+    }
+}

--- a/src/ZeroLog.Tests/LogManagerTests.cs
+++ b/src/ZeroLog.Tests/LogManagerTests.cs
@@ -14,23 +14,27 @@ namespace ZeroLog.Tests;
 [TestFixture, NonParallelizable]
 [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
 [SuppressMessage("ReSharper", "NotAccessedField.Global")]
-public class LogManagerTests
+public partial class LogManagerTests
 {
     private TestAppender _testAppender;
+    private ZeroLogConfiguration _config;
+    private LogManager _logManager;
 
     [SetUp]
     public void SetUpFixture()
     {
         _testAppender = new TestAppender(true);
 
-        LogManager.Initialize(new ZeroLogConfiguration
+        _config = new ZeroLogConfiguration
         {
             LogMessagePoolSize = 10,
             RootLogger =
             {
                 Appenders = { _testAppender }
             }
-        });
+        };
+
+        _logManager = (LogManager)LogManager.Initialize(_config);
     }
 
     [TearDown]
@@ -216,7 +220,7 @@ public class LogManagerTests
 
         signal.Wait(TimeSpan.FromSeconds(1));
 
-        var logMessage = _testAppender.LoggedMessages.Single();
+        var logMessage = _testAppender.LoggedMessages.ShouldHaveSingleItem();
         logMessage.ShouldContain("An error occurred during formatting:");
         logMessage.ShouldContain(guid.ToString(null, CultureInfo.InvariantCulture));
         logMessage.ShouldContain("abc");
@@ -237,7 +241,7 @@ public class LogManagerTests
 
         signal.Wait(TimeSpan.FromSeconds(1));
 
-        var logMessage = _testAppender.LoggedMessages.Single();
+        var logMessage = _testAppender.LoggedMessages.ShouldHaveSingleItem();
         logMessage.ShouldEqual("An error occurred during formatting: Simulated failure - Unformatted message: Unmanaged(0x2a000000)");
     }
 
@@ -280,7 +284,7 @@ public class LogManagerTests
         log.Info().Append(longMessage).Log();
 
         signal.Wait(TimeSpan.FromSeconds(1));
-        var message = _testAppender.LoggedMessages.Single();
+        var message = _testAppender.LoggedMessages.ShouldHaveSingleItem();
         message.ShouldEqual(new string('.', LogManager.OutputBufferSize - ZeroLogConfiguration.Default.TruncatedMessageSuffix.Length) + ZeroLogConfiguration.Default.TruncatedMessageSuffix);
     }
 

--- a/src/ZeroLog.Tests/Support/AssertExtensions.cs
+++ b/src/ZeroLog.Tests/Support/AssertExtensions.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using JetBrains.Annotations;
 using NUnit.Framework;
 
@@ -65,4 +66,11 @@ internal static class AssertExtensions
 
     public static void ShouldBeLessThanOrEqualTo<T>(this T? actual, T expected)
         => Assert.That(actual, Is.LessThanOrEqualTo(expected));
+
+    public static T ShouldHaveSingleItem<T>(this IEnumerable<T>? actual)
+    {
+        var list = actual as ICollection<T> ?? actual.ShouldNotBeNull().ToList();
+        Assert.That(list.Count, Is.EqualTo(1));
+        return list.Single();
+    }
 }

--- a/src/ZeroLog.Tests/TestAppender.cs
+++ b/src/ZeroLog.Tests/TestAppender.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Threading;
-using JetBrains.Annotations;
 using ZeroLog.Appenders;
 using ZeroLog.Formatting;
 
@@ -14,14 +13,10 @@ public class TestAppender : Appender
     private int _messageCountTarget;
 
     public List<string> LoggedMessages { get; } = new();
-    public int FlushCount { get; set; }
+    public int FlushCount { get; private set; }
+    public bool IsDisposed { get; private set; }
 
     public ManualResetEventSlim WaitOnWriteEvent { get; set; }
-
-    [UsedImplicitly]
-    public TestAppender()
-    {
-    }
 
     public TestAppender(bool captureLoggedMessages)
     {
@@ -52,5 +47,12 @@ public class TestAppender : Appender
         base.Flush();
 
         ++FlushCount;
+    }
+
+    public override void Dispose()
+    {
+        base.Dispose();
+
+        IsDisposed = true;
     }
 }


### PR DESCRIPTION
This PR adds an `ApplyChanges` method on `ZeroLogConfiguration`, which lets the user change the logging configuration (such as log levels) dynamically.

Calling that method will allocate.
