### PR TITLE
Replace ASCII values with UTF-8

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ There are currently three strategies to handle a full queue scenario:
 These values can be configured directly in `ZeroLogConfiguration`:
 
  - `LogMessagePoolSize` (default: `1024`) - Count of pooled log messages. A log message is acquired from the pool on demand, and released by the logging thread.
- - `LogMessageBufferSize` (default: `128`) - The size of the buffer used to serialize log message arguments. Once exceeded, the message is truncated. All `Append` calls use a few bytes, except for `AppendAsciiString` which copies the whole string into the buffer.
+ - `LogMessageBufferSize` (default: `128`) - The size of the buffer used to serialize log message arguments. Once exceeded, the message is truncated. All `Append` calls use a few bytes, except for those with a `ReadOnlySpan` parameter, which copy the whole data into the buffer.
  - `LogMessageStringCapacity` (default: `32`) - The maximum number of `Append` calls which involve `string` objects that can be made for a log message. Note that `string` objects are also used for format strings.
 
 ### Other Settings

--- a/src/ZeroLog.Impl.Base/ArgumentType.cs
+++ b/src/ZeroLog.Impl.Base/ArgumentType.cs
@@ -29,7 +29,8 @@ internal enum ArgumentType : byte
     Guid,
     DateTime,
     TimeSpan,
-    AsciiString,
+    StringSpan,
+    Utf8StringSpan,
     Enum,
     Unmanaged,
 

--- a/src/ZeroLog.Impl.Base/Log.Generated.cs
+++ b/src/ZeroLog.Impl.Base/Log.Generated.cs
@@ -385,6 +385,20 @@ partial class Log
             => Message.InternalAppendString(value);
 
         /// <summary>
+        /// Appends a string represented by a <c>ReadOnlySpan&lt;char&gt;</c> to the handler.
+        /// </summary>
+        /// <param name="value">The value to append.</param>
+        public void AppendFormatted(ReadOnlySpan<char> value)
+            => Message.InternalAppendStringSpan(value);
+
+        /// <summary>
+        /// Appends an UTF-8 string represented by a <c>ReadOnlySpanReadOnlySpan&lt;byte&gt;</c> to the handler.
+        /// </summary>
+        /// <param name="value">The value to append.</param>
+        public void AppendFormatted(ReadOnlySpan<byte> value)
+            => Message.InternalAppendUtf8StringSpan(value);
+
+        /// <summary>
         /// Appends a value of type <c>bool</c> to the handler.
         /// </summary>
         /// <param name="value">The value to append.</param>
@@ -953,6 +967,20 @@ partial class Log
         /// <param name="value">The value to append.</param>
         public void AppendFormatted(string? value)
             => Message.InternalAppendString(value);
+
+        /// <summary>
+        /// Appends a string represented by a <c>ReadOnlySpan&lt;char&gt;</c> to the handler.
+        /// </summary>
+        /// <param name="value">The value to append.</param>
+        public void AppendFormatted(ReadOnlySpan<char> value)
+            => Message.InternalAppendStringSpan(value);
+
+        /// <summary>
+        /// Appends an UTF-8 string represented by a <c>ReadOnlySpanReadOnlySpan&lt;byte&gt;</c> to the handler.
+        /// </summary>
+        /// <param name="value">The value to append.</param>
+        public void AppendFormatted(ReadOnlySpan<byte> value)
+            => Message.InternalAppendUtf8StringSpan(value);
 
         /// <summary>
         /// Appends a value of type <c>bool</c> to the handler.
@@ -1525,6 +1553,20 @@ partial class Log
             => Message.InternalAppendString(value);
 
         /// <summary>
+        /// Appends a string represented by a <c>ReadOnlySpan&lt;char&gt;</c> to the handler.
+        /// </summary>
+        /// <param name="value">The value to append.</param>
+        public void AppendFormatted(ReadOnlySpan<char> value)
+            => Message.InternalAppendStringSpan(value);
+
+        /// <summary>
+        /// Appends an UTF-8 string represented by a <c>ReadOnlySpanReadOnlySpan&lt;byte&gt;</c> to the handler.
+        /// </summary>
+        /// <param name="value">The value to append.</param>
+        public void AppendFormatted(ReadOnlySpan<byte> value)
+            => Message.InternalAppendUtf8StringSpan(value);
+
+        /// <summary>
         /// Appends a value of type <c>bool</c> to the handler.
         /// </summary>
         /// <param name="value">The value to append.</param>
@@ -2093,6 +2135,20 @@ partial class Log
         /// <param name="value">The value to append.</param>
         public void AppendFormatted(string? value)
             => Message.InternalAppendString(value);
+
+        /// <summary>
+        /// Appends a string represented by a <c>ReadOnlySpan&lt;char&gt;</c> to the handler.
+        /// </summary>
+        /// <param name="value">The value to append.</param>
+        public void AppendFormatted(ReadOnlySpan<char> value)
+            => Message.InternalAppendStringSpan(value);
+
+        /// <summary>
+        /// Appends an UTF-8 string represented by a <c>ReadOnlySpanReadOnlySpan&lt;byte&gt;</c> to the handler.
+        /// </summary>
+        /// <param name="value">The value to append.</param>
+        public void AppendFormatted(ReadOnlySpan<byte> value)
+            => Message.InternalAppendUtf8StringSpan(value);
 
         /// <summary>
         /// Appends a value of type <c>bool</c> to the handler.
@@ -2665,6 +2721,20 @@ partial class Log
             => Message.InternalAppendString(value);
 
         /// <summary>
+        /// Appends a string represented by a <c>ReadOnlySpan&lt;char&gt;</c> to the handler.
+        /// </summary>
+        /// <param name="value">The value to append.</param>
+        public void AppendFormatted(ReadOnlySpan<char> value)
+            => Message.InternalAppendStringSpan(value);
+
+        /// <summary>
+        /// Appends an UTF-8 string represented by a <c>ReadOnlySpanReadOnlySpan&lt;byte&gt;</c> to the handler.
+        /// </summary>
+        /// <param name="value">The value to append.</param>
+        public void AppendFormatted(ReadOnlySpan<byte> value)
+            => Message.InternalAppendUtf8StringSpan(value);
+
+        /// <summary>
         /// Appends a value of type <c>bool</c> to the handler.
         /// </summary>
         /// <param name="value">The value to append.</param>
@@ -3233,6 +3303,20 @@ partial class Log
         /// <param name="value">The value to append.</param>
         public void AppendFormatted(string? value)
             => Message.InternalAppendString(value);
+
+        /// <summary>
+        /// Appends a string represented by a <c>ReadOnlySpan&lt;char&gt;</c> to the handler.
+        /// </summary>
+        /// <param name="value">The value to append.</param>
+        public void AppendFormatted(ReadOnlySpan<char> value)
+            => Message.InternalAppendStringSpan(value);
+
+        /// <summary>
+        /// Appends an UTF-8 string represented by a <c>ReadOnlySpanReadOnlySpan&lt;byte&gt;</c> to the handler.
+        /// </summary>
+        /// <param name="value">The value to append.</param>
+        public void AppendFormatted(ReadOnlySpan<byte> value)
+            => Message.InternalAppendUtf8StringSpan(value);
 
         /// <summary>
         /// Appends a value of type <c>bool</c> to the handler.

--- a/src/ZeroLog.Impl.Base/Log.Generated.tt
+++ b/src/ZeroLog.Impl.Base/Log.Generated.tt
@@ -121,6 +121,20 @@ partial class Log
         public void AppendFormatted(string? value)
             => Message.InternalAppendString(value);
 
+        /// <summary>
+        /// Appends a string represented by a <c>ReadOnlySpan&lt;char&gt;</c> to the handler.
+        /// </summary>
+        /// <param name="value">The value to append.</param>
+        public void AppendFormatted(ReadOnlySpan<char> value)
+            => Message.InternalAppendStringSpan(value);
+
+        /// <summary>
+        /// Appends an UTF-8 string represented by a <c>ReadOnlySpanReadOnlySpan&lt;byte&gt;</c> to the handler.
+        /// </summary>
+        /// <param name="value">The value to append.</param>
+        public void AppendFormatted(ReadOnlySpan<byte> value)
+            => Message.InternalAppendUtf8StringSpan(value);
+
 <#
         foreach (var type in _valueTypes)
         {

--- a/src/ZeroLog.Impl.Base/LogMessage.Append.cs
+++ b/src/ZeroLog.Impl.Base/LogMessage.Append.cs
@@ -40,22 +40,22 @@ partial class LogMessage
     }
 
     /// <summary>
-    /// Appends an ASCII string to the message.
+    /// Appends a string span to the message. This will copy the span and use buffer space.
     /// </summary>
     /// <param name="value">The value to append.</param>
-    public LogMessage AppendAsciiString(ReadOnlySpan<char> value)
+    public LogMessage Append(ReadOnlySpan<char> value)
     {
-        InternalAppendAsciiString(value);
+        InternalAppendStringSpan(value);
         return this;
     }
 
     /// <summary>
-    /// Appends an ASCII string represented as bytes to the message.
+    /// Appends an UTF-8 string to the message. This will copy the span and use buffer space.
     /// </summary>
     /// <param name="value">The value to append.</param>
-    public LogMessage AppendAsciiString(ReadOnlySpan<byte> value)
+    public LogMessage Append(ReadOnlySpan<byte> value)
     {
-        InternalAppendAsciiString(value);
+        InternalAppendUtf8StringSpan(value);
         return this;
     }
 
@@ -87,10 +87,10 @@ partial class LogMessage
         where T : struct, Enum;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private partial void InternalAppendAsciiString(ReadOnlySpan<char> value);
+    internal partial void InternalAppendStringSpan(ReadOnlySpan<char> value);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private partial void InternalAppendAsciiString(ReadOnlySpan<byte> value);
+    internal partial void InternalAppendUtf8StringSpan(ReadOnlySpan<byte> value);
 
 #if NETSTANDARD
 
@@ -128,11 +128,11 @@ partial class LogMessage
     {
     }
 
-    private partial void InternalAppendAsciiString(ReadOnlySpan<char> value)
+    internal partial void InternalAppendStringSpan(ReadOnlySpan<char> value)
     {
     }
 
-    private partial void InternalAppendAsciiString(ReadOnlySpan<byte> value)
+    internal partial void InternalAppendUtf8StringSpan(ReadOnlySpan<byte> value)
     {
     }
 

--- a/src/ZeroLog.Impl.Base/LogMessage.KeyValue.cs
+++ b/src/ZeroLog.Impl.Base/LogMessage.KeyValue.cs
@@ -43,24 +43,24 @@ partial class LogMessage
     }
 
     /// <summary>
-    /// Appends a value of type ASCII string to the message metadata.
+    /// Appends a value of type string span to the message metadata. This will copy the span and use buffer space.
     /// </summary>
     /// <param name="key">The key.</param>
     /// <param name="value">The value.</param>
-    public LogMessage AppendKeyValueAscii(string key, ReadOnlySpan<char> value)
+    public LogMessage AppendKeyValue(string key, ReadOnlySpan<char> value)
     {
-        InternalAppendKeyValueAscii(key, value);
+        InternalAppendKeyValue(key, value);
         return this;
     }
 
     /// <summary>
-    /// Appends a value of type ASCII string represented as bytes to the message metadata.
+    /// Appends an UTF-8 string to the message metadata. This will copy the span and use buffer space.
     /// </summary>
     /// <param name="key">The key.</param>
     /// <param name="value">The value.</param>
-    public LogMessage AppendKeyValueAscii(string key, ReadOnlySpan<byte> value)
+    public LogMessage AppendKeyValue(string key, ReadOnlySpan<byte> value)
     {
-        InternalAppendKeyValueAscii(key, value);
+        InternalAppendKeyValue(key, value);
         return this;
     }
 
@@ -84,10 +84,10 @@ partial class LogMessage
         where T : struct, Enum;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private partial void InternalAppendKeyValueAscii(string key, ReadOnlySpan<char> value);
+    private partial void InternalAppendKeyValue(string key, ReadOnlySpan<char> value);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private partial void InternalAppendKeyValueAscii(string key, ReadOnlySpan<byte> value);
+    private partial void InternalAppendKeyValue(string key, ReadOnlySpan<byte> value);
 
 #if NETSTANDARD
 
@@ -115,11 +115,11 @@ partial class LogMessage
     {
     }
 
-    private partial void InternalAppendKeyValueAscii(string key, ReadOnlySpan<char> value)
+    private partial void InternalAppendKeyValue(string key, ReadOnlySpan<char> value)
     {
     }
 
-    private partial void InternalAppendKeyValueAscii(string key, ReadOnlySpan<byte> value)
+    private partial void InternalAppendKeyValue(string key, ReadOnlySpan<byte> value)
     {
     }
 

--- a/src/ZeroLog.Impl.Base/LogMessage.cs
+++ b/src/ZeroLog.Impl.Base/LogMessage.cs
@@ -104,6 +104,20 @@ public sealed partial class LogMessage
             => _message.InternalAppendString(value);
 
         /// <summary>
+        /// Appends a string represented by a <c>ReadOnlySpan&lt;char&gt;</c> to the handler.
+        /// </summary>
+        /// <param name="value">The value to append.</param>
+        public void AppendFormatted(ReadOnlySpan<char> value)
+            => _message.InternalAppendStringSpan(value);
+
+        /// <summary>
+        /// Appends an UTF-8 string represented by a <c>ReadOnlySpanReadOnlySpan&lt;byte&gt;</c> to the handler.
+        /// </summary>
+        /// <param name="value">The value to append.</param>
+        public void AppendFormatted(ReadOnlySpan<byte> value)
+            => _message.InternalAppendUtf8StringSpan(value);
+
+        /// <summary>
         /// Appends an enum to the handler.
         /// </summary>
         /// <param name="value">The value to append.</param>

--- a/src/ZeroLog.Impl.Full/Appenders/StreamAppender.cs
+++ b/src/ZeroLog.Impl.Full/Appenders/StreamAppender.cs
@@ -12,7 +12,7 @@ public abstract class StreamAppender : Appender
 {
     private byte[] _byteBuffer = Array.Empty<byte>();
 
-    private Encoding _encoding = new UTF8Encoding(false, false);
+    private Encoding _encoding = Encoding.UTF8;
     private Formatter? _formatter;
 
     /// <summary>

--- a/src/ZeroLog.Impl.Full/Appenders/StreamAppender.cs
+++ b/src/ZeroLog.Impl.Full/Appenders/StreamAppender.cs
@@ -12,7 +12,7 @@ public abstract class StreamAppender : Appender
 {
     private byte[] _byteBuffer = Array.Empty<byte>();
 
-    private Encoding _encoding = Encoding.UTF8;
+    private Encoding _encoding = new UTF8Encoding(false, false);
     private Formatter? _formatter;
 
     /// <summary>

--- a/src/ZeroLog.Impl.Full/Configuration/ZeroLogConfiguration.cs
+++ b/src/ZeroLog.Impl.Full/Configuration/ZeroLogConfiguration.cs
@@ -24,7 +24,7 @@ public sealed class ZeroLogConfiguration
 
     /// <summary>
     /// The size of the buffer used to serialize log message arguments. Once exceeded, the message is truncated.
-    /// All Append calls use a few bytes, except for <c>AppendAsciiString</c> which copies the whole string into the buffer.
+    /// All <c>Append</c> calls use a few bytes, except for those with a <c>ReadOnlySpan</c> parameter, which copy the whole value into the buffer.
     /// </summary>
     /// <remarks>
     /// Default: 128

--- a/src/ZeroLog.Impl.Full/LogMessage.KeyValue.Impl.cs
+++ b/src/ZeroLog.Impl.Full/LogMessage.KeyValue.Impl.cs
@@ -167,9 +167,9 @@ unsafe partial class LogMessage
         }
     }
 
-    private partial void InternalAppendKeyValueAscii(string key, ReadOnlySpan<char> value)
+    private partial void InternalAppendKeyValue(string key, ReadOnlySpan<char> value)
     {
-        if (_dataPointer + sizeof(ArgumentType) + sizeof(byte) + sizeof(ArgumentType) + sizeof(int) + value.Length <= _endOfBuffer && _stringIndex < _strings.Length)
+        if (_dataPointer + sizeof(ArgumentType) + sizeof(byte) + sizeof(ArgumentType) + sizeof(int) + value.Length * sizeof(char) <= _endOfBuffer && _stringIndex < _strings.Length)
         {
             *(ArgumentType*)_dataPointer = ArgumentType.KeyString;
             _dataPointer += sizeof(ArgumentType);
@@ -181,7 +181,7 @@ unsafe partial class LogMessage
 
             ++_stringIndex;
 
-            AppendAsciiString(value);
+            InternalAppendStringSpan(value);
         }
         else
         {
@@ -189,7 +189,7 @@ unsafe partial class LogMessage
         }
     }
 
-    private partial void InternalAppendKeyValueAscii(string key, ReadOnlySpan<byte> value)
+    private partial void InternalAppendKeyValue(string key, ReadOnlySpan<byte> value)
     {
         if (_dataPointer + sizeof(ArgumentType) + sizeof(byte) + sizeof(ArgumentType) + sizeof(int) + value.Length <= _endOfBuffer && _stringIndex < _strings.Length)
         {
@@ -203,7 +203,7 @@ unsafe partial class LogMessage
 
             ++_stringIndex;
 
-            AppendAsciiString(value);
+            InternalAppendUtf8StringSpan(value);
         }
         else
         {

--- a/src/ZeroLog.Impl.Full/LogMessage.Output.cs
+++ b/src/ZeroLog.Impl.Full/LogMessage.Output.cs
@@ -10,8 +10,6 @@ namespace ZeroLog;
 
 unsafe partial class LogMessage
 {
-    private static readonly UTF8Encoding _utf8Encoding = new(false, false);
-
     [SuppressMessage("ReSharper", "ReplaceSliceWithRangeIndexer")]
     internal int WriteTo(Span<char> outputBuffer,
                          ZeroLogConfiguration config,
@@ -366,10 +364,10 @@ unsafe partial class LogMessage
 
                 var valueBytes = new ReadOnlySpan<byte>(dataPointer, lengthInBytes);
 
-                var maxChars = _utf8Encoding.GetMaxCharCount(valueBytes.Length);
+                var maxChars = Encoding.UTF8.GetMaxCharCount(valueBytes.Length);
                 if (maxChars > outputBuffer.Length)
                 {
-                    var charCount = _utf8Encoding.GetCharCount(valueBytes);
+                    var charCount = Encoding.UTF8.GetCharCount(valueBytes);
                     if (charCount > outputBuffer.Length)
                     {
                         // There's currently no API that would truncate the string instead of throwing, so drop the value altogether.
@@ -379,7 +377,7 @@ unsafe partial class LogMessage
                     }
                 }
 
-                charsWritten = _utf8Encoding.GetChars(valueBytes, outputBuffer);
+                charsWritten = Encoding.UTF8.GetChars(valueBytes, outputBuffer);
                 dataPointer += lengthInBytes;
                 return true;
             }

--- a/src/ZeroLog.Tests/Formatting/DefaultFormatterTests.cs
+++ b/src/ZeroLog.Tests/Formatting/DefaultFormatterTests.cs
@@ -62,20 +62,20 @@ public class DefaultFormatterTests
     }
 
     [Test]
-    public void should_format_json_ascii_string_char()
+    public void should_format_json_string_span_char()
     {
         _logMessage.Append("Foo")
-                   .AppendKeyValueAscii("Hello", "World")
+                   .AppendKeyValue("Hello", "World".AsSpan())
                    .Append("Bar");
 
         GetFormattedSimple().ShouldEqual(@"FooBar ~~ { ""Hello"": ""World"" }");
     }
 
     [Test]
-    public void should_format_json_ascii_string_byte()
+    public void should_format_json_string_span_byte()
     {
         _logMessage.Append("Foo")
-                   .AppendKeyValueAscii("Hello", Encoding.ASCII.GetBytes("World"))
+                   .AppendKeyValue("Hello", Encoding.UTF8.GetBytes("World"))
                    .Append("Bar");
 
         GetFormattedSimple().ShouldEqual(@"FooBar ~~ { ""Hello"": ""World"" }");

--- a/src/ZeroLog.Tests/LogManagerTests.cs
+++ b/src/ZeroLog.Tests/LogManagerTests.cs
@@ -28,6 +28,7 @@ public partial class LogManagerTests
         _config = new ZeroLogConfiguration
         {
             LogMessagePoolSize = 10,
+            LogMessageBufferSize = 256,
             RootLogger =
             {
                 Appenders = { _testAppender }
@@ -214,7 +215,8 @@ public partial class LogManagerTests
            .Append(guid, "meh, this is going to break formatting")
            .Append(date)
            .Append(timespan)
-           .AppendAsciiString(new[] { (byte)'a', (byte)'b', (byte)'c' })
+           .Append(new[] { 'a', 'b', 'c' })
+           .Append(new[] { (byte)'d', (byte)'e', (byte)'f' })
            .AppendEnum(DayOfWeek.Friday)
            .Log();
 
@@ -224,6 +226,7 @@ public partial class LogManagerTests
         logMessage.ShouldContain("An error occurred during formatting:");
         logMessage.ShouldContain(guid.ToString(null, CultureInfo.InvariantCulture));
         logMessage.ShouldContain("abc");
+        logMessage.ShouldContain("def");
         logMessage.ShouldContain(nameof(DayOfWeek.Friday));
     }
 

--- a/src/ZeroLog.Tests/LogTests.Messages.cs
+++ b/src/ZeroLog.Tests/LogTests.Messages.cs
@@ -1,7 +1,8 @@
-
+﻿
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Text;
 using NUnit.Framework;
 using ZeroLog.Configuration;
 using ZeroLog.Tests.Support;
@@ -64,6 +65,28 @@ partial class LogTests
     public void should_log_interpolated_String_Trace()
     {
         _log.Trace($"foo {NoInline("bar")} baz {NoInline("foobar")}");
+
+        var message = _provider.GetSubmittedMessage();
+        message.Level.ShouldEqual(LogLevel.Trace);
+        message.ToString().ShouldEqual("foo bar baz foobar");
+        message.Exception.ShouldBeNull();
+    }
+
+    [Test]
+    public void should_log_interpolated_String_Span_Trace()
+    {
+        _log.Trace($"foo {"bar".AsSpan()} baz {"foobar".AsSpan()}");
+
+        var message = _provider.GetSubmittedMessage();
+        message.Level.ShouldEqual(LogLevel.Trace);
+        message.ToString().ShouldEqual("foo bar baz foobar");
+        message.Exception.ShouldBeNull();
+    }
+
+    [Test]
+    public void should_log_interpolated_Utf8_String_Span_Trace()
+    {
+        _log.Trace($"foo {Encoding.UTF8.GetBytes("bar")} baz {Encoding.UTF8.GetBytes("foobar").AsSpan()}");
 
         var message = _provider.GetSubmittedMessage();
         message.Level.ShouldEqual(LogLevel.Trace);
@@ -985,6 +1008,28 @@ partial class LogTests
     }
 
     [Test]
+    public void should_log_interpolated_String_Span_Debug()
+    {
+        _log.Debug($"foo {"bar".AsSpan()} baz {"foobar".AsSpan()}");
+
+        var message = _provider.GetSubmittedMessage();
+        message.Level.ShouldEqual(LogLevel.Debug);
+        message.ToString().ShouldEqual("foo bar baz foobar");
+        message.Exception.ShouldBeNull();
+    }
+
+    [Test]
+    public void should_log_interpolated_Utf8_String_Span_Debug()
+    {
+        _log.Debug($"foo {Encoding.UTF8.GetBytes("bar")} baz {Encoding.UTF8.GetBytes("foobar").AsSpan()}");
+
+        var message = _provider.GetSubmittedMessage();
+        message.Level.ShouldEqual(LogLevel.Debug);
+        message.ToString().ShouldEqual("foo bar baz foobar");
+        message.Exception.ShouldBeNull();
+    }
+
+    [Test]
     public void should_log_interpolated_Exception_Debug()
     {
         var exception = new InvalidOperationException();
@@ -1890,6 +1935,28 @@ partial class LogTests
     public void should_log_interpolated_String_Info()
     {
         _log.Info($"foo {NoInline("bar")} baz {NoInline("foobar")}");
+
+        var message = _provider.GetSubmittedMessage();
+        message.Level.ShouldEqual(LogLevel.Info);
+        message.ToString().ShouldEqual("foo bar baz foobar");
+        message.Exception.ShouldBeNull();
+    }
+
+    [Test]
+    public void should_log_interpolated_String_Span_Info()
+    {
+        _log.Info($"foo {"bar".AsSpan()} baz {"foobar".AsSpan()}");
+
+        var message = _provider.GetSubmittedMessage();
+        message.Level.ShouldEqual(LogLevel.Info);
+        message.ToString().ShouldEqual("foo bar baz foobar");
+        message.Exception.ShouldBeNull();
+    }
+
+    [Test]
+    public void should_log_interpolated_Utf8_String_Span_Info()
+    {
+        _log.Info($"foo {Encoding.UTF8.GetBytes("bar")} baz {Encoding.UTF8.GetBytes("foobar").AsSpan()}");
 
         var message = _provider.GetSubmittedMessage();
         message.Level.ShouldEqual(LogLevel.Info);
@@ -2811,6 +2878,28 @@ partial class LogTests
     }
 
     [Test]
+    public void should_log_interpolated_String_Span_Warn()
+    {
+        _log.Warn($"foo {"bar".AsSpan()} baz {"foobar".AsSpan()}");
+
+        var message = _provider.GetSubmittedMessage();
+        message.Level.ShouldEqual(LogLevel.Warn);
+        message.ToString().ShouldEqual("foo bar baz foobar");
+        message.Exception.ShouldBeNull();
+    }
+
+    [Test]
+    public void should_log_interpolated_Utf8_String_Span_Warn()
+    {
+        _log.Warn($"foo {Encoding.UTF8.GetBytes("bar")} baz {Encoding.UTF8.GetBytes("foobar").AsSpan()}");
+
+        var message = _provider.GetSubmittedMessage();
+        message.Level.ShouldEqual(LogLevel.Warn);
+        message.ToString().ShouldEqual("foo bar baz foobar");
+        message.Exception.ShouldBeNull();
+    }
+
+    [Test]
     public void should_log_interpolated_Exception_Warn()
     {
         var exception = new InvalidOperationException();
@@ -3724,6 +3813,28 @@ partial class LogTests
     }
 
     [Test]
+    public void should_log_interpolated_String_Span_Error()
+    {
+        _log.Error($"foo {"bar".AsSpan()} baz {"foobar".AsSpan()}");
+
+        var message = _provider.GetSubmittedMessage();
+        message.Level.ShouldEqual(LogLevel.Error);
+        message.ToString().ShouldEqual("foo bar baz foobar");
+        message.Exception.ShouldBeNull();
+    }
+
+    [Test]
+    public void should_log_interpolated_Utf8_String_Span_Error()
+    {
+        _log.Error($"foo {Encoding.UTF8.GetBytes("bar")} baz {Encoding.UTF8.GetBytes("foobar").AsSpan()}");
+
+        var message = _provider.GetSubmittedMessage();
+        message.Level.ShouldEqual(LogLevel.Error);
+        message.ToString().ShouldEqual("foo bar baz foobar");
+        message.Exception.ShouldBeNull();
+    }
+
+    [Test]
     public void should_log_interpolated_Exception_Error()
     {
         var exception = new InvalidOperationException();
@@ -4629,6 +4740,28 @@ partial class LogTests
     public void should_log_interpolated_String_Fatal()
     {
         _log.Fatal($"foo {NoInline("bar")} baz {NoInline("foobar")}");
+
+        var message = _provider.GetSubmittedMessage();
+        message.Level.ShouldEqual(LogLevel.Fatal);
+        message.ToString().ShouldEqual("foo bar baz foobar");
+        message.Exception.ShouldBeNull();
+    }
+
+    [Test]
+    public void should_log_interpolated_String_Span_Fatal()
+    {
+        _log.Fatal($"foo {"bar".AsSpan()} baz {"foobar".AsSpan()}");
+
+        var message = _provider.GetSubmittedMessage();
+        message.Level.ShouldEqual(LogLevel.Fatal);
+        message.ToString().ShouldEqual("foo bar baz foobar");
+        message.Exception.ShouldBeNull();
+    }
+
+    [Test]
+    public void should_log_interpolated_Utf8_String_Span_Fatal()
+    {
+        _log.Fatal($"foo {Encoding.UTF8.GetBytes("bar")} baz {Encoding.UTF8.GetBytes("foobar").AsSpan()}");
 
         var message = _provider.GetSubmittedMessage();
         message.Level.ShouldEqual(LogLevel.Fatal);

--- a/src/ZeroLog.Tests/LogTests.Messages.tt
+++ b/src/ZeroLog.Tests/LogTests.Messages.tt
@@ -26,6 +26,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Text;
 using NUnit.Framework;
 using ZeroLog.Configuration;
 using ZeroLog.Tests.Support;
@@ -92,6 +93,28 @@ partial class LogTests
     public void should_log_interpolated_String_<#= logLevel #>()
     {
         _log.<#= logLevel #>($"foo {NoInline("bar")} baz {NoInline("foobar")}");
+
+        var message = _provider.GetSubmittedMessage();
+        message.Level.ShouldEqual(LogLevel.<#= logLevel #>);
+        message.ToString().ShouldEqual("foo bar baz foobar");
+        message.Exception.ShouldBeNull();
+    }
+
+    [Test]
+    public void should_log_interpolated_String_Span_<#= logLevel #>()
+    {
+        _log.<#= logLevel #>($"foo {"bar".AsSpan()} baz {"foobar".AsSpan()}");
+
+        var message = _provider.GetSubmittedMessage();
+        message.Level.ShouldEqual(LogLevel.<#= logLevel #>);
+        message.ToString().ShouldEqual("foo bar baz foobar");
+        message.Exception.ShouldBeNull();
+    }
+
+    [Test]
+    public void should_log_interpolated_Utf8_String_Span_<#= logLevel #>()
+    {
+        _log.<#= logLevel #>($"foo {Encoding.UTF8.GetBytes("bar")} baz {Encoding.UTF8.GetBytes("foobar").AsSpan()}");
 
         var message = _provider.GetSubmittedMessage();
         message.Level.ShouldEqual(LogLevel.<#= logLevel #>);


### PR DESCRIPTION
This replaces the ASCII encoding of spans with Unicode:

- Appending a `ReadOnlySpan<char>` will copy UTF-16 bytes (instead of stripping the upper byte)
- Appending a `ReadOnlySpan<byte>` will copy UTF-8 bytes

C# 11 will add support for UTF-8 string literals which will be represented as `ReadOnlySpan<byte>`, therefore interpreting `ReadOnlySpan<byte>` as an UTF-8 string will become idiomatic. This PR prepares for that. It's a breaking API change (which is OK before the stable v2.0 is released).

Note that 7-bit ASCII is valid UTF-8, so updating shouldn't be an issue.

This also adds support for spans (of `char` and `byte`) in interpolated strings.
