### PR TITLE
support IsBackround option for logger thread

### DIFF
--- a/src/ZeroLog.Impl.Full/Configuration/ZeroLogConfiguration.cs
+++ b/src/ZeroLog.Impl.Full/Configuration/ZeroLogConfiguration.cs
@@ -52,9 +52,13 @@ public sealed class ZeroLogConfiguration
     /// Flag indicating to use a background thread for appending log messages.
     /// </summary>
     /// <remarks>
-    /// If a background thread is used the application exit won't wait for <see cref="LogManager.Shutdown"/>
-    /// This allows hooking LogManager.Shutdown calls to AppDomain.CurrentDomain.ProcessExit events as this event is otherwise blocked by foreground thread
-    /// Default: false
+    /// <para>
+    /// If a background thread is used the application exit won't wait for <see cref="LogManager.Shutdown"/>.
+    /// This allows hooking <c>LogManager.Shutdown</c> calls to <c>AppDomain.CurrentDomain.ProcessExit</c> events as this event is otherwise blocked by a foreground thread.
+    /// </para>
+    /// <para>
+    /// Default: false.
+    /// </para>
     /// </remarks>
     public bool UseBackgroundThread { get; init; } = false;
 

--- a/src/ZeroLog.Impl.Full/Configuration/ZeroLogConfiguration.cs
+++ b/src/ZeroLog.Impl.Full/Configuration/ZeroLogConfiguration.cs
@@ -49,6 +49,16 @@ public sealed class ZeroLogConfiguration
     public bool AutoRegisterEnums { get; set; } = false;
 
     /// <summary>
+    /// Flag indicating to use background thread for flushing to appenders.
+    /// </summary>
+    /// <remarks>
+    /// If background thread is used application exit will not waiting for <see cref="LogManager.Shutdown"/>
+    /// This allows hooking LogManager.Shutdown calls to AppDomain.CurrentDomain.ProcessExit events as this event is otherwise blocked by foreground thread
+    /// Default: false
+    /// </remarks>
+    public bool UseBackgroundThread { get; set; } = false;
+
+    /// <summary>
     /// The string which should be logged instead of a <c>null</c> value.
     /// </summary>
     /// <remarks>

--- a/src/ZeroLog.Impl.Full/Configuration/ZeroLogConfiguration.cs
+++ b/src/ZeroLog.Impl.Full/Configuration/ZeroLogConfiguration.cs
@@ -56,7 +56,7 @@ public sealed class ZeroLogConfiguration
     /// This allows hooking LogManager.Shutdown calls to AppDomain.CurrentDomain.ProcessExit events as this event is otherwise blocked by foreground thread
     /// Default: false
     /// </remarks>
-    public bool UseBackgroundThread { get; set; } = false;
+    public bool UseBackgroundThread { get; init; } = false;
 
     /// <summary>
     /// The string which should be logged instead of a <c>null</c> value.

--- a/src/ZeroLog.Impl.Full/Configuration/ZeroLogConfiguration.cs
+++ b/src/ZeroLog.Impl.Full/Configuration/ZeroLogConfiguration.cs
@@ -52,7 +52,7 @@ public sealed class ZeroLogConfiguration
     /// Flag indicating to use background thread for flushing to appenders.
     /// </summary>
     /// <remarks>
-    /// If background thread is used application exit will not waiting for <see cref="LogManager.Shutdown"/>
+    /// If a background thread is used the application exit won't wait for <see cref="LogManager.Shutdown"/>
     /// This allows hooking LogManager.Shutdown calls to AppDomain.CurrentDomain.ProcessExit events as this event is otherwise blocked by foreground thread
     /// Default: false
     /// </remarks>

--- a/src/ZeroLog.Impl.Full/Configuration/ZeroLogConfiguration.cs
+++ b/src/ZeroLog.Impl.Full/Configuration/ZeroLogConfiguration.cs
@@ -49,7 +49,7 @@ public sealed class ZeroLogConfiguration
     public bool AutoRegisterEnums { get; set; } = false;
 
     /// <summary>
-    /// Flag indicating to use background thread for flushing to appenders.
+    /// Flag indicating to use a background thread for appending log messages.
     /// </summary>
     /// <remarks>
     /// If a background thread is used the application exit won't wait for <see cref="LogManager.Shutdown"/>

--- a/src/ZeroLog.Impl.Full/LogManager.AppenderThread.cs
+++ b/src/ZeroLog.Impl.Full/LogManager.AppenderThread.cs
@@ -33,7 +33,8 @@ partial class LogManager
 
             _thread = new Thread(WriteThread)
             {
-                Name = $"{nameof(ZeroLog)}.{nameof(AppenderThread)}"
+                Name = $"{nameof(ZeroLog)}.{nameof(AppenderThread)}",
+                IsBackground = _config.UseBackgroundThread
             };
 
             _thread.Start();


### PR DESCRIPTION
Using IsBackround=true  allows hooking LogManager.Shutdown calls to AppDomain.CurrentDomain.ProcessExit events as this event is otherwise blocked by running foreground thread