### PR TITLE
feat: drop redundant fixed for already pinned array

### DIFF
--- a/src/ZeroLog.Impl.Full/BufferSegmentProvider.cs
+++ b/src/ZeroLog.Impl.Full/BufferSegmentProvider.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.InteropServices;
 
 namespace ZeroLog;
 
@@ -41,21 +42,17 @@ internal unsafe class BufferSegmentProvider
                 _currentSegment = 0;
             }
 
-            fixed (byte* data = &_currentBuffer[_segmentSize * _currentSegment++])
-            {
-                return new BufferSegment(data, _segmentSize, _currentBuffer);
-            }
+            var offset = _segmentSize * _currentSegment++;
+            var data = (byte*)Marshal.UnsafeAddrOfPinnedArrayElement(_currentBuffer, offset);
+            return new BufferSegment(data, _segmentSize, _currentBuffer);
         }
     }
 
     public static BufferSegment CreateStandaloneSegment(int bufferSize)
     {
         var buffer = GC.AllocateUninitializedArray<byte>(bufferSize, pinned: true);
-
-        fixed (byte* data = buffer)
-        {
-            return new BufferSegment(data, bufferSize, buffer);
-        }
+        var data = (byte*)Marshal.UnsafeAddrOfPinnedArrayElement(buffer, 0);
+        return new BufferSegment(data, bufferSize, buffer);
     }
 }
 


### PR DESCRIPTION
`fixed` is redundant here, as array is already pinned. Small asm comparison to justify the change:
https://sharplab.io/#v2:EYLgZgpghgLgrgJwgZwLQGED2AbbEDGMAlpgHYAyRMECU2yANDCFMgLYA+AAgEwCMAWABQXAAwACLnwB0AJTilibCNICSimpgAOAZRoA3IvhQBuYcK4BmST3HpxAb2HiX4566viFyKJHHIYBDhCcQAhODBIBD0Ac2VFAApgAE9qACpxABNYKAZxIkVxPFIYmAALPJTqAG0AXQB+L1JMmmxkgpjwyJoASncXJyFXYclrJChMsjbxKogMgBEc8QBeLJyzIZGXT3HJ0mmCmHFyCBLylaLT0rKNre2x6D3p2brGgFVm1vaSrqiLhRaCDaHV+NFurgAvuZNi5+m4YaMmj4/KDohA4qcjgBBBKHGYRKI6IgALwgPUccOG+igCHx3VpqwA4uhpFjcJh8LAIB8ClQiHQSRBMliELRkgAeWYAPiSBJoRNJeS0BVIQpA4kCcDJG0prjARAAHkLxElUnM1jAoBdgHKEH0EcNBncRlwAOziVUAdzCtti8RgCWylsqvsFIfpPXBWyhCJjwzhnm8vggPvpfsxYVxhRtacF5Kdd2ptJzfyZLLZ2A5XJ5pD5AtJwtFUAl0tlucV4mVpFVmXVmu1uthDtcRc7gQupvSPQAsjTkGU6NIPsiIFjMpkEAB5MAABRVQpFYoAonh/W2onlRJHB5J3V7U4T0WetIFw4Sw3SotfY8IIUA===