### PR TITLE
Use managed ref instead of fixed

### DIFF
--- a/src/ZeroLog.Impl.Full/Formatting/LoggedKeyValue.cs
+++ b/src/ZeroLog.Impl.Full/Formatting/LoggedKeyValue.cs
@@ -111,58 +111,56 @@ public readonly unsafe ref struct LoggedKeyValue
             return false;
         }
 
-        fixed (byte* rawDataPointer = _rawData)
+        ref var rawDataRef = ref MemoryMarshal.GetReference(_rawData);
+        var valueType = (ArgumentType)rawDataRef; // There is no FormatFlag in this context
+        ref var dataRef = ref Unsafe.Add(ref rawDataRef, sizeof(ArgumentType));
+
+        switch (valueType)
         {
-            var valueType = *(ArgumentType*)rawDataPointer; // There is no FormatFlag in this context
-            var dataPointer = rawDataPointer + sizeof(ArgumentType);
-
-            switch (valueType)
+            case ArgumentType.Char when typeof(T) == typeof(char):
+            case ArgumentType.Boolean when typeof(T) == typeof(bool):
+            case ArgumentType.Byte when typeof(T) == typeof(byte):
+            case ArgumentType.SByte when typeof(T) == typeof(sbyte):
+            case ArgumentType.Int16 when typeof(T) == typeof(short):
+            case ArgumentType.UInt16 when typeof(T) == typeof(ushort):
+            case ArgumentType.Int32 when typeof(T) == typeof(int):
+            case ArgumentType.UInt32 when typeof(T) == typeof(uint):
+            case ArgumentType.Int64 when typeof(T) == typeof(long):
+            case ArgumentType.UInt64 when typeof(T) == typeof(ulong):
+            case ArgumentType.IntPtr when typeof(T) == typeof(nint):
+            case ArgumentType.UIntPtr when typeof(T) == typeof(nuint):
+            case ArgumentType.Single when typeof(T) == typeof(float):
+            case ArgumentType.Double when typeof(T) == typeof(double):
+            case ArgumentType.Decimal when typeof(T) == typeof(decimal):
+            case ArgumentType.Guid when typeof(T) == typeof(Guid):
+            case ArgumentType.DateTime when typeof(T) == typeof(DateTime):
+            case ArgumentType.TimeSpan when typeof(T) == typeof(TimeSpan):
+            case ArgumentType.DateOnly when typeof(T) == typeof(DateOnly):
+            case ArgumentType.TimeOnly when typeof(T) == typeof(TimeOnly):
+            case ArgumentType.DateTimeOffset when typeof(T) == typeof(DateTimeOffset):
             {
-                case ArgumentType.Char when typeof(T) == typeof(char):
-                case ArgumentType.Boolean when typeof(T) == typeof(bool):
-                case ArgumentType.Byte when typeof(T) == typeof(byte):
-                case ArgumentType.SByte when typeof(T) == typeof(sbyte):
-                case ArgumentType.Int16 when typeof(T) == typeof(short):
-                case ArgumentType.UInt16 when typeof(T) == typeof(ushort):
-                case ArgumentType.Int32 when typeof(T) == typeof(int):
-                case ArgumentType.UInt32 when typeof(T) == typeof(uint):
-                case ArgumentType.Int64 when typeof(T) == typeof(long):
-                case ArgumentType.UInt64 when typeof(T) == typeof(ulong):
-                case ArgumentType.IntPtr when typeof(T) == typeof(nint):
-                case ArgumentType.UIntPtr when typeof(T) == typeof(nuint):
-                case ArgumentType.Single when typeof(T) == typeof(float):
-                case ArgumentType.Double when typeof(T) == typeof(double):
-                case ArgumentType.Decimal when typeof(T) == typeof(decimal):
-                case ArgumentType.Guid when typeof(T) == typeof(Guid):
-                case ArgumentType.DateTime when typeof(T) == typeof(DateTime):
-                case ArgumentType.TimeSpan when typeof(T) == typeof(TimeSpan):
-                case ArgumentType.DateOnly when typeof(T) == typeof(DateOnly):
-                case ArgumentType.TimeOnly when typeof(T) == typeof(TimeOnly):
-                case ArgumentType.DateTimeOffset when typeof(T) == typeof(DateTimeOffset):
-                {
-                    result = Unsafe.Read<T>(dataPointer);
-                    return true;
-                }
-
-                case ArgumentType.Enum:
-                {
-                    var argPtr = (EnumArg*)dataPointer;
-                    return argPtr->TryGetValue<T>(out result);
-                }
-
-                case ArgumentType.Unmanaged:
-                {
-                    var argPtr = (UnmanagedArgHeader*)dataPointer;
-                    if (typeof(T) != argPtr->Type)
-                        break;
-
-                    result = Unsafe.Read<T>(argPtr + sizeof(UnmanagedArgHeader));
-                    return true;
-                }
+                result = Unsafe.As<byte, T>(ref dataRef);
+                return true;
             }
 
-            result = default;
-            return false;
+            case ArgumentType.Enum:
+            {
+                return Unsafe.As<byte, EnumArg>(ref dataRef).TryGetValue<T>(out result);
+            }
+
+            case ArgumentType.Unmanaged:
+            {
+                ref var header = ref Unsafe.As<byte, UnmanagedArgHeader>(ref dataRef);
+                if (typeof(T) != header.Type)
+                    break;
+
+                ref var valueRef = ref Unsafe.Add(ref dataRef, sizeof(UnmanagedArgHeader));
+                result = Unsafe.As<byte, T>(ref valueRef);
+                return true;
+            }
         }
+
+        result = default;
+        return false;
     }
 }


### PR DESCRIPTION
There is no need to use `fixed` here. I thought we can use pointer directly, but `_rawData` might not be backed only by pinned data. Using `ref MemoryMarshal.GetReference` and `Unsafe.As` can provide same semantics as raw pointer, but without using pointer.

https://sharplab.io/#v2:EYLgZgpghgLgrgJwgZwLQGED2AbbEDGMAlpgHYAyRMECU2yANDCFMgLYA+AAgEwCMAWABQXAAwACLnwB0AJTilibCNKxsADkTwIAyjQBuRfCgDcwsZJnzFRZdICSimpnV6Eh48jNDzAZnEKyFCQkjzi6MIA3sLisXFc/kSK4gDyCEQA5kl0APqOMAAUstAAJimk2ACeOupQpAA8wJXUAHziJbBQAJQxcbHRQn1D4mBEAB4QJeIFTdQAVOLq4gC87Z09g8NxA1tb+lAIizCHq0sA1OJ83rvDXADs4gCqpEGQcqX1STAtBerHXdcbgBfXp9EE+TZ9BLiL7iYpgACCyDyiiKpXKVRqdUazQgbQ6MG6oO2xOGSDA4n2hxO4nJ4gAshA2JgEJV6QdkAALOjSADiEBg8JoEFIxgKBO6gN2dKp7RWtIgFOerxUCJKJQKdIQDEuANJQ3uTxewVVyBx1B1Xx+dJKeshcXB+uhsPhzzomVIkxRhWKUDKFWqtQaszxa0JG2GOxuMoOtPldMZzNZ7IQXJ5/MFiuFoog4vWUq2McOU1WdOVJukao1Wp1fDtN0kD3Lb19JTd2A9k0+imtiva9aGjvtsWhvLgRCmaUy2WwOTHE7RfoxgexIfx631Ud2owmUxmuIWS1WEojNy3Dcpsb+NPOlwLDcNzZUrfq85KP2vA924OGQ9u/jfOFFSROdxw1VtlyxYNcXXcNN31PoizjUs+0TFk2Q5blsD5AUhSQHM83De8hiQksFSVY03irTU+21XViKhJtKNNc0IB1N9ewpW1iL/A0ALAoCwHbTsSlAhcIIDKDWNgolh3Ec8yT7WUaQTJl0JTNNsIzPCRTFE8GLiUj4z7J9K3VGiKTousDJHJiVXeP1hIyT0SlfMDOP7HjeiBIA